### PR TITLE
docs: sync CLAUDE.md and roadmap with facts from PR #53's review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,8 @@ npm run lint
 npm run format
 npx tsc --noEmit
 npm test
-npm run test:integration   # real Postgres+pgvector required; not run in CI
+npm run test:integration   # real Postgres+pgvector required; already covered by plain 'npm test'
+                            # (no path exclusion in jest config), including in CI
 npm run seed:dev           # guarded
 npx prisma generate
 npx prisma migrate dev

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -37,7 +37,7 @@ truth for status; the issues are. Re-sync this file whenever a linked issue's st
   position in this list implies
 - Reference only, not a work item: #36 (architecture diagram)
 
-### New items surfaced by the review series (not yet tracked as issues)
+### New items surfaced by the review series
 
 These were originally found by actually reading the code end-to-end during a review series whose
 working files lived under `docs/handoff/` and have since been cleaned up. Three of the four now

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -39,10 +39,12 @@ truth for status; the issues are. Re-sync this file whenever a linked issue's st
 
 ### New items surfaced by the review series (not yet tracked as issues)
 
-These didn't exist as roadmap items before because they were only found by actually reading the
-code end-to-end (see `docs/handoff/` for the full review series: `step3-architecture-diff.md`,
-`architecture-review.md`, `contracts-review.md`, `flows-review.md`). Recommend filing each as its
-own issue rather than leaving them here as prose.
+These were originally found by actually reading the code end-to-end during a review series whose
+working files lived under `docs/handoff/` and have since been cleaned up. Three of the four now
+have permanent replacements: `docs/02-architecture.md` §11 (Architectural Decision Log),
+`docs/05-api-contract.md`, and `docs/07-flows-review.md`. `step3-architecture-diff.md` has no
+permanent replacement yet — tracked in issue #58. Most items below are now tracked as their own
+issues (P01–P18); a few still aren't — check the tracker before assuming one below is untracked.
 
 **Do now (cheap today, expensive later):**
 
@@ -112,6 +114,18 @@ product decision that should be made explicitly rather than discovered by omissi
   one question in, one answer out — no way to thread multi-turn context server-side).
 - [ ] Either way: decide on streaming vs. full-response for the LLM call before frontend work
   commits to one UX pattern.
+
+**Surfaced during the docs-accuracy review (PR #53), tracked but not yet in this list:**
+
+- [ ] #56 — Add a Python dependency manifest for the embedding service.
+- [ ] #57 — `vector-storage.integration.test.ts` has no isolation from shared `DocumentChunk`
+  data (`searchSimilarChunks` has no `sourceType` filter).
+- [ ] #58 — Remaining dangling `docs/handoff/*` references in `docs/01-product.md` and this file.
+- [ ] #59 — `chunkDocument`'s empty-content behavior contradicts
+  `docs/03-chunker-architecture.md`'s documented invariant (code-vs-doc call needed).
+- [ ] #60 — Ingestion has no error handling around embedding failures and its lock is
+  in-process-only; directly relevant to #40.
+- [ ] #61 — `/ai-agent` returns 500 instead of 400 for a body-less request.
 
 ---
 


### PR DESCRIPTION
Follow-up to PR #53. That review round established facts this repo's own reference docs hadn't caught up to yet:

- `CLAUDE.md` §10 claimed `npm run test:integration` "is not run in CI" — verified false: jest's `testMatch` has no exclusion for `tests/integration/`, and CI provisions a pgvector service specifically because plain `npm test` already runs that suite there.
- `docs/04-implementation-roadmap.md` still cited the deleted `docs/handoff/` review-series files by name — three of the four now have permanent replacements (`docs/02-architecture.md` §11, `docs/05-api-contract.md`, `docs/07-flows-review.md`); the fourth (`step3-architecture-diff.md`) is tracked in issue #58.
- The same roadmap section's "not yet tracked as issues" framing was stale — most of its items already have issue numbers (P01–P18).
- Added issues #56–#61 (filed during PR #53's review round) to the roadmap's index so they're not only in the tracker.

No code changes — docs only.