### PR TITLE
[P02] Fix the journal-intent response to return prose, not raw JSON

### DIFF
--- a/src/ai-agent/ai-agent-orchestrator.ts
+++ b/src/ai-agent/ai-agent-orchestrator.ts
@@ -1,8 +1,10 @@
 import { safetyTool } from './tools/safety-tool.js';
 import { ragTool } from './tools/rag-tool.js';
-import { journalTool } from './tools/journal-tool.js';
+import { journalTool, formatInjuryRecord } from './tools/journal-tool.js';
 import { routeIntent } from './ai-agent-intent-router.js';
 import { AgentState } from './ai-agent-state.js';
+import { buildPrompt } from '../rag/prompt-builder.js';
+import { generateAnswer } from '../llm/llm-client.js';
 
 export async function runAgent(question: string, injuryId?: number) {
   const state: AgentState = {
@@ -47,12 +49,12 @@ export async function runAgent(question: string, injuryId?: number) {
         };
       }
 
-      // TODO: Remove for now because JournalTool is palceholder
-      // Change later
-      //state.result = result;
+      const context = formatInjuryRecord(result);
+      const prompt = buildPrompt(question, context);
+      const answer = await generateAnswer(prompt);
 
       return {
-        answer: JSON.stringify(result),
+        answer,
         citations: [],
       };
     }

--- a/src/ai-agent/ai-agent-orchestrator.ts
+++ b/src/ai-agent/ai-agent-orchestrator.ts
@@ -53,6 +53,14 @@ export async function runAgent(question: string, injuryId?: number) {
       const prompt = buildPrompt(question, context);
       const answer = await generateAnswer(prompt);
 
+      if (!answer) {
+        return {
+          answer:
+            'Unable to generate a summary from your injury record right now.',
+          citations: [],
+        };
+      }
+
       return {
         answer,
         citations: [],

--- a/src/ai-agent/tools/journal-tool.ts
+++ b/src/ai-agent/tools/journal-tool.ts
@@ -17,3 +17,55 @@ export async function journalTool(injuryId: number) {
 
   return injury;
 }
+
+type InjuryRecord = NonNullable<Awaited<ReturnType<typeof journalTool>>>;
+
+export function formatInjuryRecord(injury: InjuryRecord): string {
+  const sections: string[] = [];
+
+  const details = [
+    `Name: ${injury.name}`,
+    `Body area: ${injury.bodyArea}${injury.side ? ` (${injury.side})` : ''}`,
+    `Start date: ${injury.startDate.toISOString().slice(0, 10)}`,
+  ];
+
+  if (injury.cause) details.push(`Cause: ${injury.cause}`);
+  if (injury.status) details.push(`Status: ${injury.status}`);
+  if (injury.description) details.push(`Description: ${injury.description}`);
+
+  sections.push(`Injury:\n${details.join('\n')}`);
+
+  if (injury.Symptom.length > 0) {
+    const symptoms = injury.Symptom.map(
+      (symptom) =>
+        `- ${symptom.date.toISOString().slice(0, 10)}: pain level ${symptom.painLevel}${symptom.location ? ` at ${symptom.location}` : ''}${symptom.notes ? ` — ${symptom.notes}` : ''}`,
+    ).join('\n');
+    sections.push(`Symptoms:\n${symptoms}`);
+  }
+
+  if (injury.Treatment.length > 0) {
+    const treatments = injury.Treatment.map(
+      (treatment) =>
+        `- ${treatment.date.toISOString().slice(0, 10)}: ${treatment.name}${treatment.provider ? ` (${treatment.provider})` : ''}${treatment.outcome ? ` — outcome: ${treatment.outcome}` : ''}`,
+    ).join('\n');
+    sections.push(`Treatments:\n${treatments}`);
+  }
+
+  if (injury.TimelineEvent.length > 0) {
+    const events = injury.TimelineEvent.map(
+      (event) =>
+        `- ${event.date.toISOString().slice(0, 10)}: ${event.type} — ${event.description}${event.result ? ` (${event.result})` : ''}`,
+    ).join('\n');
+    sections.push(`Timeline events:\n${events}`);
+  }
+
+  if (injury.MedicalVisit.length > 0) {
+    const visits = injury.MedicalVisit.map(
+      (visit) =>
+        `- ${visit.date.toISOString().slice(0, 10)}${visit.doctor ? `: ${visit.doctor}` : ''}${visit.clinic ? ` at ${visit.clinic}` : ''}${visit.notes ? ` — ${visit.notes}` : ''}`,
+    ).join('\n');
+    sections.push(`Medical visits:\n${visits}`);
+  }
+
+  return sections.join('\n\n');
+}

--- a/tests/ai-agent-orchestrator.test.ts
+++ b/tests/ai-agent-orchestrator.test.ts
@@ -3,7 +3,9 @@ import { jest } from '@jest/globals';
 const safetyToolMock = jest.fn();
 const ragToolMock = jest.fn();
 const journalToolMock = jest.fn();
+const formatInjuryRecordMock = jest.fn();
 const routeIntentMock = jest.fn();
+const generateAnswerMock = jest.fn();
 
 jest.unstable_mockModule('../src/ai-agent/tools/safety-tool.js', () => ({
   safetyTool: safetyToolMock,
@@ -15,10 +17,15 @@ jest.unstable_mockModule('../src/ai-agent/tools/rag-tool.js', () => ({
 
 jest.unstable_mockModule('../src/ai-agent/tools/journal-tool.js', () => ({
   journalTool: journalToolMock,
+  formatInjuryRecord: formatInjuryRecordMock,
 }));
 
 jest.unstable_mockModule('../src/ai-agent/ai-agent-intent-router.js', () => ({
   routeIntent: routeIntentMock,
+}));
+
+jest.unstable_mockModule('../src/llm/llm-client.js', () => ({
+  generateAnswer: generateAnswerMock,
 }));
 
 const { runAgent } = await import('../src/ai-agent/ai-agent-orchestrator.js');
@@ -113,18 +120,26 @@ describe('agent orchestrator', () => {
       id: 42,
     });
 
+    formatInjuryRecordMock.mockReturnValue('Injury:\nName: Sprained ankle');
+
+    generateAnswerMock.mockResolvedValue(
+      'Your sprained ankle injury started on record.',
+    );
+
     const result = await runAgent('Show my injury timeline', 42);
 
     expect(routeIntentMock).toHaveBeenCalledWith('Show my injury timeline');
 
     expect(journalToolMock).toHaveBeenCalledWith(42);
 
+    expect(formatInjuryRecordMock).toHaveBeenCalledWith({ id: 42 });
+
+    expect(generateAnswerMock).toHaveBeenCalled();
+
     expect(ragToolMock).not.toHaveBeenCalled();
 
-    // TODO: Update this expectation when journalTool is implemented
-    // to transform structured injury data into a user-facing answer.
     expect(result).toEqual({
-      answer: JSON.stringify({ id: 42 }),
+      answer: 'Your sprained ankle injury started on record.',
       citations: [],
     });
   });

--- a/tests/ai-agent-orchestrator.test.ts
+++ b/tests/ai-agent-orchestrator.test.ts
@@ -143,4 +143,30 @@ describe('agent orchestrator', () => {
       citations: [],
     });
   });
+
+  it('returns a fallback message when the LLM returns an empty answer for journal questions', async () => {
+    safetyToolMock.mockReturnValue({
+      allowed: true,
+    });
+
+    routeIntentMock.mockReturnValue('journal');
+
+    journalToolMock.mockResolvedValue({
+      id: 42,
+    });
+
+    formatInjuryRecordMock.mockReturnValue('Injury:\nName: Sprained ankle');
+
+    generateAnswerMock.mockResolvedValue('');
+
+    const result = await runAgent('Show my injury timeline', 42);
+
+    expect(generateAnswerMock).toHaveBeenCalled();
+
+    expect(result).toEqual({
+      answer:
+        'Unable to generate a summary from your injury record right now.',
+      citations: [],
+    });
+  });
 });

--- a/tests/integration/ai-agent-route.integration.test.ts
+++ b/tests/integration/ai-agent-route.integration.test.ts
@@ -12,9 +12,9 @@ jest.unstable_mockModule('../../src/llm/llm-client.js', () => ({
   generateAnswer: jest.fn(),
 }));
 
-const { default: app } = await import('../../src/app.js');
 const { embedQuery } = await import('../../src/embeddings/embedding-client.js');
 const { generateAnswer } = await import('../../src/llm/llm-client.js');
+const { default: app } = await import('../../src/app.js');
 
 const mockEmbedQuery = jest.mocked(embedQuery);
 const mockGenerateAnswer = jest.mocked(generateAnswer);

--- a/tests/integration/ai-agent-route.integration.test.ts
+++ b/tests/integration/ai-agent-route.integration.test.ts
@@ -121,12 +121,15 @@ describe('AI agent route integration', () => {
 
     expect(response.status).toBe(200);
 
-    expect(response.body.answer).toContain('AI Agent Route Test');
+    expect(response.body.answer).toBe('mocked agent answer');
 
     expect(response.body.citations).toEqual([]);
 
     expect(mockEmbedText).not.toHaveBeenCalled();
-    expect(mockGenerateAnswer).not.toHaveBeenCalled();
+
+    expect(mockGenerateAnswer).toHaveBeenCalledTimes(1);
+
+    expect(mockGenerateAnswer.mock.calls[0][0]).toContain('AI Agent Route Test');
   });
 
   it('requires an injuryId for journal questions', async () => {

--- a/tests/integration/ai-agent-route.integration.test.ts
+++ b/tests/integration/ai-agent-route.integration.test.ts
@@ -132,6 +132,25 @@ describe('AI agent route integration', () => {
     expect(mockGenerateAnswer.mock.calls[0][0]).toContain('AI Agent Route Test');
   });
 
+  it('returns a fallback message when journal answer generation is empty', async () => {
+    mockGenerateAnswer.mockResolvedValue('');
+
+    const response = await request(app).post('/ai-agent').send({
+      question: 'Show me my injury timeline',
+      injuryId,
+    });
+
+    expect(response.status).toBe(200);
+
+    expect(response.body).toEqual({
+      answer:
+        'Unable to generate a summary from your injury record right now.',
+      citations: [],
+    });
+
+    expect(mockGenerateAnswer).toHaveBeenCalledTimes(1);
+  });
+
   it('requires an injuryId for journal questions', async () => {
     const response = await request(app).post('/ai-agent').send({
       question: 'Show me my injury timeline',

--- a/tests/integration/rag-route.integration.test.ts
+++ b/tests/integration/rag-route.integration.test.ts
@@ -12,9 +12,9 @@ jest.unstable_mockModule('../../src/llm/llm-client.js', () => ({
   generateAnswer: jest.fn(),
 }));
 
-const { default: app } = await import('../../src/app.js');
 const { embedQuery } = await import('../../src/embeddings/embedding-client.js');
 const { generateAnswer } = await import('../../src/llm/llm-client.js');
+const { default: app } = await import('../../src/app.js');
 
 const mockEmbedQuery = jest.mocked(embedQuery);
 const mockGenerateAnswer = jest.mocked(generateAnswer);

--- a/tests/journal-tool.test.ts
+++ b/tests/journal-tool.test.ts
@@ -1,0 +1,125 @@
+import { formatInjuryRecord } from '../src/ai-agent/tools/journal-tool.js';
+
+function baseInjury() {
+  return {
+    id: 1,
+    name: 'Sprained ankle',
+    bodyArea: 'ankle',
+    side: null,
+    startDate: new Date('2026-01-05'),
+    cause: null,
+    description: null,
+    status: null,
+    createdAt: new Date('2026-01-05'),
+    userId: 1,
+    Treatment: [],
+    Symptom: [],
+    TimelineEvent: [],
+    MedicalVisit: [],
+  };
+}
+
+describe('formatInjuryRecord', () => {
+  it('formats a minimal record with no optional fields or relations', () => {
+    const result = formatInjuryRecord(baseInjury());
+
+    expect(result).toBe(
+      'Injury:\nName: Sprained ankle\nBody area: ankle\nStart date: 2026-01-05',
+    );
+  });
+
+  it('includes optional injury fields and the side annotation when present', () => {
+    const injury = {
+      ...baseInjury(),
+      side: 'left',
+      cause: 'Fell while running',
+      status: 'Recovering',
+      description: 'Rolled ankle on uneven pavement',
+    };
+
+    const result = formatInjuryRecord(injury);
+
+    expect(result).toBe(
+      [
+        'Injury:',
+        'Name: Sprained ankle',
+        'Body area: ankle (left)',
+        'Start date: 2026-01-05',
+        'Cause: Fell while running',
+        'Status: Recovering',
+        'Description: Rolled ankle on uneven pavement',
+      ].join('\n'),
+    );
+  });
+
+  it('formats symptoms, treatments, timeline events, and medical visits when present', () => {
+    const injury = {
+      ...baseInjury(),
+      Symptom: [
+        {
+          id: 1,
+          date: new Date('2026-01-06'),
+          painLevel: 6,
+          location: 'ankle',
+          trigger: null,
+          duration: null,
+          notes: 'Worse after walking',
+          injuryId: 1,
+        },
+        {
+          id: 2,
+          date: new Date('2026-01-10'),
+          painLevel: 3,
+          location: null,
+          trigger: null,
+          duration: null,
+          notes: null,
+          injuryId: 1,
+        },
+      ],
+      Treatment: [
+        {
+          id: 1,
+          name: 'Physiotherapy',
+          provider: 'Dr. Lee',
+          date: new Date('2026-01-08'),
+          cost: null,
+          outcome: 'Improved mobility',
+          injuryId: 1,
+        },
+      ],
+      TimelineEvent: [
+        {
+          id: 1,
+          type: 'follow-up',
+          date: new Date('2026-01-12'),
+          description: 'Reassessed range of motion',
+          result: 'Cleared for light activity',
+          injuryId: 1,
+        },
+      ],
+      MedicalVisit: [
+        {
+          id: 1,
+          doctor: 'Dr. Lee',
+          clinic: 'Downtown Clinic',
+          date: new Date('2026-01-07'),
+          notes: 'X-ray clear',
+          injuryId: 1,
+        },
+      ],
+    };
+
+    const result = formatInjuryRecord(injury);
+
+    expect(result).toBe(
+      [
+        'Injury:\nName: Sprained ankle\nBody area: ankle\nStart date: 2026-01-05',
+        'Symptoms:\n- 2026-01-06: pain level 6 at ankle — Worse after walking\n- 2026-01-10: pain level 3',
+        'Treatments:\n- 2026-01-08: Physiotherapy (Dr. Lee) — outcome: Improved mobility',
+        'Timeline events:\n- 2026-01-12: follow-up — Reassessed range of motion (Cleared for light activity)',
+        'Medical visits:\n- 2026-01-07: Dr. Lee at Downtown Clinic — X-ray clear',
+      ].join('\n\n'),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #38

Replaces the raw `JSON.stringify(result)` answer in the AI agent's
`journal` intent with a generated prose summary: the injury record is
formatted into readable context (`formatInjuryRecord` in
`journal-tool.ts`) and passed through the existing prompt-builder /
LLM-client path (`buildPrompt` + `generateAnswer`) also used by the
RAG path.

Updated `ai-agent-orchestrator.test.ts` and the
`ai-agent-route.integration.test.ts` journal-intent case to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Journal questions now return clear, AI-generated answers instead of raw record data.
  * Injury information is organized into readable responses, including details such as symptoms, treatments, timelines, and medical visits when available.
* **Bug Fixes**
  * Improved journal responses so relevant injury information is consistently included in the generated answer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->