### PR TITLE
docs: annotate roadmap items with tracking issue numbers

### DIFF
--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -48,54 +48,54 @@ issues (P01–P18); a few still aren't — check the tracker before assuming one
 
 **Do now (cheap today, expensive later):**
 
-- [ ] Wire `embed_query()` into the actual query-embedding path. The embedding service already
+- [x] Wire `embed_query()` into the actual query-embedding path. The embedding service already
   implements Qwen3's asymmetric query/document prompting; the query path just never calls it.
-  Highest value-to-effort fix in the whole review.
+  Highest value-to-effort fix in the whole review. (#37)
 - [ ] Build the actual ingestion worker/entrypoint. Every stage (read → build → chunk → embed →
   store) works and is tested in isolation; nothing calls them in sequence outside test files, so
-  `DocumentChunk` is never populated in a running system today.
+  `DocumentChunk` is never populated in a running system today. (#40)
 - [ ] Fix the journal-intent response in `/ai-agent` — it currently returns
   `JSON.stringify(injury)` inside a prose `answer` field. This will render as raw JSON in any
-  real frontend and needs to change before frontend work starts, not alongside it.
+  real frontend and needs to change before frontend work starts, not alongside it. (#38)
 - [ ] Add a real, indexed `userId` column on `DocumentChunk` (denormalized from `Injury.userId`
   at write time). This is a schema migration, and #31's authorization work depends on it existing
-  first — today `userId` only lives inside an unindexed JSON blob and cannot be filtered on.
+  first — today `userId` only lives inside an unindexed JSON blob and cannot be filtered on. (#41)
 - [ ] Start threading a request ID through the pipeline now, even as a no-op passed-through
-  parameter, rather than retrofitting it into every function signature once #32 starts.
+  parameter, rather than retrofitting it into every function signature once #32 starts. (#42)
 - [ ] Add a test for the empty-retrieval path in `answerQuestion` (zero chunks found → what does
   the LLM actually do with an empty context block?). Likely the common case until the ingestion
-  worker above exists.
+  worker above exists. (#39)
 
 **Fold into Step 5 / #31 (security), more concretely scoped than the current issue text:**
 
 - [ ] Authentication + session/identity on every request (currently: zero — every request is
-  anonymous server-side).
+  anonymous server-side). (#31)
 - [ ] Per-tool authorization step in the agent orchestrator — does not exist today, not even
-  partially.
+  partially. (#31)
 - [ ] Decide the fate of `POST /rag/ask` vs `POST /ai-agent` before scoping authorization work —
   they're two public, unauthenticated, differently-validated entrypoints to overlapping
-  functionality today.
+  functionality today. (#43)
 - [ ] Regression tests for data isolation boundaries specifically (requested explicitly in #31's
   own text) — currently zero tests exist proving cross-user chunk leakage can't happen when
-  `injuryId` is omitted.
+  `injuryId` is omitted. (#31)
 - [ ] Output-side safety check — the current safety layer is entirely pre-generation; nothing
-  checks whether the LLM's answer echoes diagnosis-adjacent language from a chunk's raw content.
+  checks whether the LLM's answer echoes diagnosis-adjacent language from a chunk's raw content. (#31)
 
 **Fold into Step 9 backlog cleanup / general hygiene (not urgent, but shouldn't be lost):**
 
 - [ ] Delete or finish `src/ai-agent/ai-agent-service.ts` — a second, unused, partially-dead
-  duplicate of `ai-agent-orchestrator.ts`.
+  duplicate of `ai-agent-orchestrator.ts`. (#46)
 - [ ] Resolve the three unwired citation modules (`citation-verifier.ts`,
   `citation-formatter.ts`, `citation-source-mapper.ts`) — either wire them into the response path
   as #35 already plans, or remove them; two of the three only handle 2 of 5 valid `sourceType`
-  values (`treatment`, `medical_visit` — missing `symptom`, `timeline_event`, `injury`).
+  values (`treatment`, `medical_visit` — missing `symptom`, `timeline_event`, `injury`). (not yet filed)
 - [ ] Consolidate `PrismaClient` instantiation behind `src/lib/prisma.ts` — four files construct
-  their own client independently today.
+  their own client independently today. (#47)
 - [ ] Add `journal-tool.ts` test coverage — zero tests exist for it despite it being one of three
-  response branches in the agent.
+  response branches in the agent. (#44)
 - [ ] Surface `AgentState.intent` in the actual HTTP response — it's computed, tracked, and then
-  discarded; a frontend needs exactly this field to know which response shape it received.
-- [ ] Clean up the stray Python test functions embedded at module level in `embedding_api.py`.
+  discarded; a frontend needs exactly this field to know which response shape it received. (#45)
+- [ ] Clean up the stray Python test functions embedded at module level in `embedding_api.py`. (#48)
 
 **Frontend-readiness gaps — new "Step 10" candidate, sequenced after Step 5 (security), since
 building frontend-facing endpoints without auth would just mean redoing them:**
@@ -107,13 +107,13 @@ product decision that should be made explicitly rather than discovered by omissi
 - [ ] **Decide:** does this backend own journal CRUD + auth going forward, or does a separate
   "existing Injury Journal application" (per `docs/02-architecture.md`'s framing) own that, with
   this repo staying read-only/AI-only? This changes the entire scope of what comes next and isn't
-  written down anywhere today.
+  written down anywhere today. (#49)
 - [ ] If this backend owns it: `POST/GET/PATCH/DELETE` for `Injury` and its child records,
-  `GET /injuries` (list), login/session endpoints, a `GET /me` identity endpoint.
+  `GET /injuries` (list), login/session endpoints, a `GET /me` identity endpoint. (#50)
 - [ ] Either way: a conversation/thread concept for the assistant (currently fully stateless,
-  one question in, one answer out — no way to thread multi-turn context server-side).
+  one question in, one answer out — no way to thread multi-turn context server-side). (#51)
 - [ ] Either way: decide on streaming vs. full-response for the LLM call before frontend work
-  commits to one UX pattern.
+  commits to one UX pattern. (#52)
 
 **Surfaced during the docs-accuracy review (PR #53), tracked but not yet in this list:**
 


### PR DESCRIPTION
Appends the actual issue number (or "not yet filed") to each bullet in the "New items surfaced by the review series" section, so it's clear item-by-item which are already tracked and which aren't.

Closes #63