### PR TITLE
fix: guard against undefined req.body in /ai-agent controller

### DIFF
--- a/src/ai-agent/ai-agent-controller.ts
+++ b/src/ai-agent/ai-agent-controller.ts
@@ -3,7 +3,7 @@ import { runAgent } from './ai-agent-orchestrator.js';
 
 export async function askAgent(req: Request, res: Response) {
   try {
-    const { question, injuryId } = req.body;
+    const { question, injuryId } = req.body ?? {};
 
     if (typeof question !== 'string' || question.trim().length === 0) {
       return res.status(400).json({

--- a/tests/ai-agent-controller.test.ts
+++ b/tests/ai-agent-controller.test.ts
@@ -104,6 +104,21 @@ describe('ai agent controller', () => {
     expect(runAgentMock).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when req.body is undefined', async () => {
+    const req: MockRequest = {};
+
+    const res = mockResponse();
+
+    await askAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Question is required',
+    });
+
+    expect(runAgentMock).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when injuryId is not a number', async () => {
     const req: MockRequest = {
       body: {


### PR DESCRIPTION
## Summary
- Express 5 leaves `req.body` `undefined` for a body-less request, which previously threw before question validation ran and surfaced as a 500 instead of the documented 400.
- Matches the `req.body ?? {}` pattern already used in `rag-controller.ts`.

Fixes #61

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (added a test for `req.body === undefined`, full suite passes: 37 suites / 160 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of requests with missing or null bodies.
  - Requests without a question now return a clear 400 error instead of causing a failure.

- **Tests**
  - Added coverage to verify the expected error response and prevent unnecessary agent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->