### PR TITLE
[P27] Ingestion has no error handling around embedding failures

### DIFF
--- a/src/ingestion/embed-and-store.ts
+++ b/src/ingestion/embed-and-store.ts
@@ -16,44 +16,33 @@ export async function embedAndStoreDocument(
     document.metadata.sourceId,
     async () => {
       const chunks = chunkDocument(document);
-      const storedIndexes: number[] = [];
 
-      try {
-        for (const [chunkIndex, chunk] of chunks.entries()) {
-          const embedding = await embedText(chunk.content);
+      for (const [chunkIndex, chunk] of chunks.entries()) {
+        const embedding = await embedText(chunk.content);
 
-          const embeddedDocument: EmbeddedDocument = {
-            document: chunk,
-            embedding: embedding.embedding,
-            embeddingMetadata: {
-              model: embedding.model,
-              modelVersion: embedding.modelVersion,
-              vectorDimension: embedding.dimension,
-              embeddingVersion: embedding.version,
-            },
-          };
+        const embeddedDocument: EmbeddedDocument = {
+          document: chunk,
+          embedding: embedding.embedding,
+          embeddingMetadata: {
+            model: embedding.model,
+            modelVersion: embedding.modelVersion,
+            vectorDimension: embedding.dimension,
+            embeddingVersion: embedding.version,
+          },
+        };
 
-          await storeDocumentChunk(
-            embeddedDocument.document.metadata.injuryId,
-            embeddedDocument.document.metadata.sourceType,
-            embeddedDocument.document.metadata.sourceId,
-            chunkIndex,
-            embeddedDocument.document.content,
-            embeddedDocument.embedding,
-            {
-              ...embeddedDocument.document.metadata,
-              embedding: embeddedDocument.embeddingMetadata,
-            },
-          );
-          storedIndexes.push(chunkIndex);
-        }
-      } catch (error) {
-        await deleteDocumentChunksExcept(
-          document.metadata.sourceType,
-          document.metadata.sourceId,
-          storedIndexes,
+        await storeDocumentChunk(
+          embeddedDocument.document.metadata.injuryId,
+          embeddedDocument.document.metadata.sourceType,
+          embeddedDocument.document.metadata.sourceId,
+          chunkIndex,
+          embeddedDocument.document.content,
+          embeddedDocument.embedding,
+          {
+            ...embeddedDocument.document.metadata,
+            embedding: embeddedDocument.embeddingMetadata,
+          },
         );
-        throw error;
       }
 
       await deleteDocumentChunksExcept(

--- a/src/ingestion/embed-and-store.ts
+++ b/src/ingestion/embed-and-store.ts
@@ -16,33 +16,44 @@ export async function embedAndStoreDocument(
     document.metadata.sourceId,
     async () => {
       const chunks = chunkDocument(document);
+      const storedIndexes: number[] = [];
 
-      for (const [chunkIndex, chunk] of chunks.entries()) {
-        const embedding = await embedText(chunk.content);
+      try {
+        for (const [chunkIndex, chunk] of chunks.entries()) {
+          const embedding = await embedText(chunk.content);
 
-        const embeddedDocument: EmbeddedDocument = {
-          document: chunk,
-          embedding: embedding.embedding,
-          embeddingMetadata: {
-            model: embedding.model,
-            modelVersion: embedding.modelVersion,
-            vectorDimension: embedding.dimension,
-            embeddingVersion: embedding.version,
-          },
-        };
+          const embeddedDocument: EmbeddedDocument = {
+            document: chunk,
+            embedding: embedding.embedding,
+            embeddingMetadata: {
+              model: embedding.model,
+              modelVersion: embedding.modelVersion,
+              vectorDimension: embedding.dimension,
+              embeddingVersion: embedding.version,
+            },
+          };
 
-        await storeDocumentChunk(
-          embeddedDocument.document.metadata.injuryId,
-          embeddedDocument.document.metadata.sourceType,
-          embeddedDocument.document.metadata.sourceId,
-          chunkIndex,
-          embeddedDocument.document.content,
-          embeddedDocument.embedding,
-          {
-            ...embeddedDocument.document.metadata,
-            embedding: embeddedDocument.embeddingMetadata,
-          },
+          await storeDocumentChunk(
+            embeddedDocument.document.metadata.injuryId,
+            embeddedDocument.document.metadata.sourceType,
+            embeddedDocument.document.metadata.sourceId,
+            chunkIndex,
+            embeddedDocument.document.content,
+            embeddedDocument.embedding,
+            {
+              ...embeddedDocument.document.metadata,
+              embedding: embeddedDocument.embeddingMetadata,
+            },
+          );
+          storedIndexes.push(chunkIndex);
+        }
+      } catch (error) {
+        await deleteDocumentChunksExcept(
+          document.metadata.sourceType,
+          document.metadata.sourceId,
+          storedIndexes,
         );
+        throw error;
       }
 
       await deleteDocumentChunksExcept(

--- a/tests/embed-and-store.test.ts
+++ b/tests/embed-and-store.test.ts
@@ -222,7 +222,7 @@ describe('embedAndStoreDocument', () => {
     );
   });
 
-  it('propagates an embedding error and prunes to what was already stored', async () => {
+  it('propagates an embedding error and stops processing further chunks', async () => {
     const document = makeDocument();
     const chunk1 = { content: 'a', metadata: document.metadata };
     const chunk2 = { content: 'b', metadata: document.metadata };
@@ -238,35 +238,46 @@ describe('embedAndStoreDocument', () => {
 
     expect(embedTextMock).toHaveBeenCalledTimes(1);
     expect(storeDocumentChunkMock).not.toHaveBeenCalled();
-    expect(deleteDocumentChunksExceptMock).toHaveBeenCalledTimes(1);
-    expect(deleteDocumentChunksExceptMock).toHaveBeenCalledWith(
-      document.metadata.sourceType,
-      document.metadata.sourceId,
-      [],
-    );
+    expect(deleteDocumentChunksExceptMock).not.toHaveBeenCalled();
   });
 
-  it('propagates a storage error and prunes to what was already stored', async () => {
+  it('propagates a storage error without pruning stale chunks', async () => {
     const document = makeDocument();
     chunkDocumentMock.mockReturnValue([
       { content: 'a', metadata: document.metadata },
-      { content: 'b', metadata: document.metadata },
     ]);
     embedTextMock.mockResolvedValue(fakeEmbedding());
-    storeDocumentChunkMock
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error('db unavailable'));
+    storeDocumentChunkMock.mockRejectedValueOnce(new Error('db unavailable'));
 
     await expect(embedAndStoreDocument(document)).rejects.toThrow(
       'db unavailable',
     );
 
-    expect(deleteDocumentChunksExceptMock).toHaveBeenCalledTimes(1);
-    expect(deleteDocumentChunksExceptMock).toHaveBeenCalledWith(
-      document.metadata.sourceType,
-      document.metadata.sourceId,
-      [0],
+    expect(deleteDocumentChunksExceptMock).not.toHaveBeenCalled();
+  });
+
+  it('does not delete previously-stored chunks after a transient mid-document failure', async () => {
+    const document = makeDocument();
+    chunkDocumentMock.mockReturnValue([
+      { content: 'a', metadata: document.metadata },
+      { content: 'b', metadata: document.metadata },
+      { content: 'c', metadata: document.metadata },
+    ]);
+    embedTextMock.mockResolvedValue(fakeEmbedding());
+    storeDocumentChunkMock
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('transient db blip'));
+
+    await expect(embedAndStoreDocument(document)).rejects.toThrow(
+      'transient db blip',
     );
+
+    // Chunks 0 and 1 were durably stored before the failure on chunk 2.
+    // A failed run must not prune anything: the chunks it didn't reach
+    // (e.g. a previously-stored chunk 2) may still be valid and are not
+    // known to be stale just because this attempt didn't get to them.
+    expect(deleteDocumentChunksExceptMock).not.toHaveBeenCalled();
   });
 
   it('serializes concurrent ingestion calls for the same sourceType/sourceId', async () => {

--- a/tests/embed-and-store.test.ts
+++ b/tests/embed-and-store.test.ts
@@ -222,7 +222,7 @@ describe('embedAndStoreDocument', () => {
     );
   });
 
-  it('propagates an embedding error and stops processing further chunks', async () => {
+  it('propagates an embedding error and prunes to what was already stored', async () => {
     const document = makeDocument();
     const chunk1 = { content: 'a', metadata: document.metadata };
     const chunk2 = { content: 'b', metadata: document.metadata };
@@ -238,22 +238,35 @@ describe('embedAndStoreDocument', () => {
 
     expect(embedTextMock).toHaveBeenCalledTimes(1);
     expect(storeDocumentChunkMock).not.toHaveBeenCalled();
-    expect(deleteDocumentChunksExceptMock).not.toHaveBeenCalled();
+    expect(deleteDocumentChunksExceptMock).toHaveBeenCalledTimes(1);
+    expect(deleteDocumentChunksExceptMock).toHaveBeenCalledWith(
+      document.metadata.sourceType,
+      document.metadata.sourceId,
+      [],
+    );
   });
 
-  it('propagates a storage error without pruning stale chunks', async () => {
+  it('propagates a storage error and prunes to what was already stored', async () => {
     const document = makeDocument();
     chunkDocumentMock.mockReturnValue([
       { content: 'a', metadata: document.metadata },
+      { content: 'b', metadata: document.metadata },
     ]);
     embedTextMock.mockResolvedValue(fakeEmbedding());
-    storeDocumentChunkMock.mockRejectedValueOnce(new Error('db unavailable'));
+    storeDocumentChunkMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('db unavailable'));
 
     await expect(embedAndStoreDocument(document)).rejects.toThrow(
       'db unavailable',
     );
 
-    expect(deleteDocumentChunksExceptMock).not.toHaveBeenCalled();
+    expect(deleteDocumentChunksExceptMock).toHaveBeenCalledTimes(1);
+    expect(deleteDocumentChunksExceptMock).toHaveBeenCalledWith(
+      document.metadata.sourceType,
+      document.metadata.sourceId,
+      [0],
+    );
   });
 
   it('serializes concurrent ingestion calls for the same sourceType/sourceId', async () => {


### PR DESCRIPTION
Addresses #60

## Summary
`embedAndStoreDocument()` loops over a document's chunks calling
`embedText()`/`storeDocumentChunk()` with no try/catch. A mid-loop
failure leaves already-stored chunks in place and skips
`deleteDocumentChunksExcept()` entirely.

An earlier version of this PR made the failure path prune down to
only the chunks stored so far. On review, that turned out to trade
one bug for a worse one: it would delete previously-good chunks that
simply hadn't been reprocessed yet in a transient-failure run (e.g. a
momentary embedding-service blip), causing real data loss instead of
just leaving stale data in place. That approach has been reverted.

This PR now only adds a regression test locking in the existing safe
behavior — a failed run must never prune anything, since a partial
attempt can't distinguish "genuinely stale" from "not reached yet."
No production behavior changes.

## Scope
Only the error-handling gap from #60 is addressed (by confirming/
locking in the safe non-pruning behavior via test). The second gap in
that issue — the in-process-only ingestion lock providing no
cross-process protection — remains open and untouched: no ingestion
worker exists yet to run multiple processes (#40), and the issue
itself ties that decision to the not-yet-made embedding-service
sidecar/long-lived decision (docs/02-architecture.md §9).

Using "Addresses #60" rather than "Fixes #60" since #60 covers two
gaps and this PR only speaks to one of them — merging should not
auto-close the issue.

## Tests
- Restored the two existing tests asserting no pruning happens on
  embedding/storage failure.
- Added a new regression test for a transient mid-document failure
  (chunks 0-1 stored, chunk 2 fails) asserting
  `deleteDocumentChunksExcept` is never called.
