### PR TITLE
docs: sync CLAUDE.md and roadmap with #38, #60, #61 outcomes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,8 @@ MUST run before retrieval. All LLM calls MUST go through the existing LLM client
 (`src/llm/llm-client.ts`) — do not call a provider SDK directly elsewhere.
 
 Known unfinished pieces that affect future changes: no worker currently runs the ingestion
-pipeline end-to-end outside tests; the agent's `journal` intent returns a raw DB record instead of
-an LLM summary; citations are built from what was retrieved, not verified against what the LLM
-actually said.
+pipeline end-to-end outside tests; citations are built from what was retrieved, not verified
+against what the LLM actually said.
 
 See `docs/02-architecture.md` for full diagrams. **That document describes intended design — it
 is not proof of current implementation.** Where it and the code disagree, the code is correct;
@@ -151,8 +150,8 @@ request/response fields, error statuses, or domain-object schemas here.
 - Current endpoints: `POST /rag/ask`, `POST /ai-agent`. **The API is currently unauthenticated.**
 - `/ai-agent`'s response shape depends on which intent ran, and no field in the response
   indicates which — check `ai-agent-orchestrator.ts` before building against it.
-- `/ai-agent`'s `journal` intent returns a stringified raw DB record as the `answer` field, not
-  prose — known placeholder behavior, not a stable contract.
+- `/ai-agent`'s `journal` intent returns LLM-generated prose summarizing the injury record (with
+  a fallback message if the LLM returns an empty answer) — not a raw DB record.
 - No CRUD, login/session, conversation state, or streaming exist yet.
 
 ---

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -22,7 +22,7 @@ truth for status; the issues are. Re-sync this file whenever a linked issue's st
   - [x] 2.4 Basic RAG (#26)
   - [x] 2.5 Citations *(generation only — verification not wired in, see below)* (#27)
   - [x] 2.6 Safety Guardrails *(input-side only — no output-side check)* (#28)
-  - [x] 2.7 AI Agent *(keyword routing, not per-tool authorization; journal path incomplete)* (#29)
+  - [x] 2.7 AI Agent *(keyword routing, not per-tool authorization)* (#29)
 - [x] Step 3 — Evaluation *(harness exists; two of four dimensions are shallow, one is unimplemented)* (#30)
 - [x] Step 4 — Integration Tests (#17)
 
@@ -54,9 +54,9 @@ issue number, or marked "not yet filed" where none exists yet.
 - [ ] Build the actual ingestion worker/entrypoint. Every stage (read → build → chunk → embed →
   store) works and is tested in isolation; nothing calls them in sequence outside test files, so
   `DocumentChunk` is never populated in a running system today. (#40)
-- [ ] Fix the journal-intent response in `/ai-agent` — it currently returns
-  `JSON.stringify(injury)` inside a prose `answer` field. This will render as raw JSON in any
-  real frontend and needs to change before frontend work starts, not alongside it. (#38)
+- [x] Fix the journal-intent response in `/ai-agent` — previously returned
+  `JSON.stringify(injury)` inside a prose `answer` field; now returns an LLM-generated prose
+  summary of the injury record. (#38)
 - [ ] Add a real, indexed `userId` column on `DocumentChunk` (denormalized from `Injury.userId`
   at write time). This is a schema migration, and #31's authorization work depends on it existing
   first — today `userId` only lives inside an unindexed JSON blob and cannot be filtered on. (#41)
@@ -123,9 +123,11 @@ product decision that should be made explicitly rather than discovered by omissi
 - [ ] #58 — Remaining dangling `docs/handoff/*` references in `docs/01-product.md` and this file.
 - [ ] #59 — `chunkDocument`'s empty-content behavior contradicts
   `docs/03-chunker-architecture.md`'s documented invariant (code-vs-doc call needed).
-- [ ] #60 — Ingestion has no error handling around embedding failures and its lock is
-  in-process-only; directly relevant to #40.
-- [ ] #61 — `/ai-agent` returns 500 instead of 400 for a body-less request.
+- [x] #60 — Ingestion error handling: investigated, confirmed the existing partial-failure
+  behavior (no pruning on a failed run) is already safe; locked in via a regression test, no
+  code change needed. Cross-process locking (the other half of #60) remains unaddressed — tied
+  to the not-yet-built ingestion worker (#40).
+- [x] #61 — `/ai-agent` returns 500 instead of 400 for a body-less request.
 
 ---
 

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -127,7 +127,7 @@ product decision that should be made explicitly rather than discovered by omissi
   behavior (no pruning on a failed run) is already safe; locked in via a regression test, no
   code change needed. Cross-process locking (the other half of #60) remains unaddressed — tied
   to the not-yet-built ingestion worker (#40).
-- [x] #61 — `/ai-agent` returns 500 instead of 400 for a body-less request.
+- [x] #61 — `/ai-agent` now returns 400 instead of 500 for a body-less request.
 
 ---
 


### PR DESCRIPTION
- Journal-intent response is now LLM prose, not a raw DB record (#38, merged via PR #65) — update both the Architecture "known unfinished pieces" note and the Frontend Contract section.
- Mark #38 and #61 done in the roadmap's tracked-issue lists.
- Mark #60 done with a precise annotation: the error-handling half was investigated and confirmed already-safe (locked in via a regression test, no code change needed); the cross-process locking half remains unaddressed, tied to the not-yet-built ingestion worker (#40).
- Drop the now-stale "journal path incomplete" annotation on Step 2.7.