### PR TITLE
[P26] chunkDocument's empty-content behavior contradicts its own documented invariant

### DIFF
--- a/src/ingestion/chunking/document-chunker.ts
+++ b/src/ingestion/chunking/document-chunker.ts
@@ -42,6 +42,10 @@ export function chunkDocument(
   document: JournalDocument,
   maxTokens: number = DEFAULT_MAX_TOKENS,
 ): JournalDocument[] {
+  if (!document.content.trim()) {
+    return [];
+  }
+
   // Keep small journal records intact.
   if (countTokens(document.content) <= maxTokens) {
     return [document];

--- a/tests/chunker.test.ts
+++ b/tests/chunker.test.ts
@@ -92,6 +92,21 @@ describe('Document Chunker', () => {
     expect(chunks.length).toBeGreaterThan(2);
   });
 
+  it('produces no chunks for empty or whitespace-only content', () => {
+    const emptyDocument: JournalDocument = {
+      content: '   ',
+      metadata: {
+        userId: 1,
+        injuryId: 1,
+        sourceType: 'treatment',
+        sourceId: 3,
+        date: new Date('2025-03-01'),
+      },
+    };
+
+    expect(chunkDocument(emptyDocument, 100)).toEqual([]);
+  });
+
   it('splits a sentence that exceeds the token limit', () => {
     const chunks = chunkDocument(oversizedSentenceDocument, 20);
 


### PR DESCRIPTION
Fixes #59

Adds an empty/whitespace-only content guard to `chunkDocument()`'s fast path in `src/ingestion/chunking/document-chunker.ts`, matching the invariant already documented in `docs/03-chunker-architecture.md` ("Empty content doesn't create chunks") and already enforced on the multi-chunk split path via `addChunk()`. Adds a covering unit test.

This PR is stacked on #71 and depends on it merging first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documents containing only blank spaces or whitespace are now handled correctly without producing empty chunks.

* **Tests**
  * Added coverage to verify whitespace-only documents return no chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->