### PR TITLE
[P03] Add a test for the empty-retrieval path in answerQuestion

### DIFF
--- a/tests/rag-service.test.ts
+++ b/tests/rag-service.test.ts
@@ -158,6 +158,41 @@ describe('rag service', () => {
     expect(buildCitationsMock).not.toHaveBeenCalled();
   });
 
+  it('still generates an answer when retrieval finds zero chunks', async () => {
+    semanticSearchMock.mockResolvedValue([]);
+
+    buildContextMock.mockReturnValue('');
+
+    buildPromptMock.mockReturnValue('prompt with empty context');
+
+    generateAnswerMock.mockResolvedValue(
+      'I do not have enough information to answer that.',
+    );
+
+    buildCitationsMock.mockReturnValue([]);
+
+    const result = await answerQuestion('What treatments have I tried?');
+
+    expect(buildContextMock).toHaveBeenCalledWith([]);
+
+    expect(buildPromptMock).toHaveBeenCalledWith(
+      'What treatments have I tried?',
+      '',
+    );
+
+    expect(generateAnswerMock).toHaveBeenCalledWith(
+      'prompt with empty context',
+    );
+
+    expect(buildCitationsMock).toHaveBeenCalledWith([]);
+
+    expect(result).toEqual({
+      answer: 'I do not have enough information to answer that.',
+      citations: [],
+      chunks: [],
+    });
+  });
+
   it('propagates retrieval errors', async () => {
     semanticSearchMock.mockRejectedValue(new Error('search failed'));
 


### PR DESCRIPTION
Fixes #39

Adds a regression test for `answerQuestion()`'s zero-chunk retrieval path, which had no
coverage before. Traced the current (unchanged) behavior end-to-end:

- `buildContext([])` returns `''`
- `buildPrompt(question, '')` still embeds that empty string, relying entirely on the LLM
  to follow the prompt's own "say you don't have enough information" instruction
- `answerQuestion` has no early return for zero chunks — it proceeds through
  `buildContext` → `buildPrompt` → `generateAnswer` → `buildCitations` unchanged

No production code changed — this is a test-only issue per its "quick win" framing, and the
current behavior traced above is correct as-is (see CLAUDE.md §6, which already notes the
"no relevant information found" content rule isn't enforced in `prompt-builder.ts`).