### PR TITLE
fix: scope vector-storage integration test to its own sourceType

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -215,8 +215,9 @@ flowchart TD
 
 > **Current status:** "Question Embedding" now uses the query-specific `/embed-query` endpoint as
 > of PR #55 (issue #37) — see §4.2's design-gap note for the merge-status caveat. "Metadata
-> Filtering" is `injuryId` only; `userId`, `sourceType`, and date-range filters are not
-> implemented (deliberately deferred pending evaluation data, per issue #35). There is no
+> Filtering" is `injuryId` only in production; `searchSimilarChunks` also accepts an optional
+> `sourceType` parameter, but no production caller passes one. `userId` and date-range filters are
+> not implemented (deliberately deferred pending evaluation data, per issue #35). There is no
 > similarity threshold — "Top-k Relevant Chunks" really means "Top-k *Nearest* Chunks," which may
 > not be relevant at all if the journal has little or no ingested content for the question asked.
 

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -118,8 +118,9 @@ product decision that should be made explicitly rather than discovered by omissi
 **Surfaced during the docs-accuracy review (PR #53), tracked but not yet in this list:**
 
 - [ ] #56 — Add a Python dependency manifest for the embedding service.
-- [ ] #57 — `vector-storage.integration.test.ts` has no isolation from shared `DocumentChunk`
-  data (`searchSimilarChunks` has no `sourceType` filter).
+- [x] #57 — `vector-storage.integration.test.ts` has no isolation from shared `DocumentChunk`
+  data: fixed by adding an optional `sourceType` filter to `searchSimilarChunks` and scoping the
+  test to it. Not used by any production caller.
 - [ ] #58 — Remaining dangling `docs/handoff/*` references in `docs/01-product.md` and this file.
 - [ ] #59 — `chunkDocument`'s empty-content behavior contradicts
   `docs/03-chunker-architecture.md`'s documented invariant (code-vs-doc call needed).

--- a/docs/05-api-contract.md
+++ b/docs/05-api-contract.md
@@ -16,8 +16,8 @@ identity/session endpoints, no health check.
 **None.** There is no auth middleware anywhere in `app.ts`/`index.ts`, no session, and no
 `userId` derived from request context at any layer. Every request is anonymous. Concretely:
 
-- `searchSimilarChunks` (`vector-storage.ts`) filters only by the optional `injuryId` — never by
-  owner.
+- `searchSimilarChunks` (`vector-storage.ts`) filters only by the optional `injuryId` (it also
+  accepts an optional `sourceType`, but no production caller passes one) — never by owner.
 - `journalTool` (`journal-tool.ts`) does a bare `prisma.injury.findUnique({ where: { id } })` —
   no owner check.
 

--- a/src/embeddings/vector-storage.ts
+++ b/src/embeddings/vector-storage.ts
@@ -90,8 +90,16 @@ export async function searchSimilarChunks(
   embedding: number[],
   injuryId?: number,
   limit = 5,
+  sourceType?: string,
 ) {
   const vector = `[${embedding.join(',')}]`;
+
+  const filters: Prisma.Sql[] = [];
+  if (injuryId !== undefined) filters.push(Prisma.sql`"injuryId" = ${injuryId}`);
+  if (sourceType !== undefined) filters.push(Prisma.sql`"sourceType" = ${sourceType}`);
+
+  const whereClause =
+    filters.length > 0 ? Prisma.sql`WHERE ${Prisma.join(filters, ' AND ')}` : Prisma.empty;
 
   return prisma.$queryRaw<SearchSimilarChunk[]>(
     Prisma.sql`
@@ -105,11 +113,7 @@ export async function searchSimilarChunks(
         "metadata",
         "embedding" <=> ${vector}::vector AS "distance"
       FROM "DocumentChunk"
-      ${
-        injuryId !== undefined
-          ? Prisma.sql`WHERE "injuryId" = ${injuryId}`
-          : Prisma.empty
-      }
+      ${whereClause}
       ORDER BY "embedding" <=> ${vector}::vector
       LIMIT ${limit}
     `,

--- a/tests/integration/vector-storage.integration.test.ts
+++ b/tests/integration/vector-storage.integration.test.ts
@@ -149,4 +149,39 @@ describe('vector storage integration', () => {
     expect(results[0].content).toBe('Injury 1 relevant chunk');
     expect(results[0].injuryId).toBe(1);
   });
+
+  it('excludes rows from a different sourceType even when their vector is closer', async () => {
+    await storeDocumentChunk(
+      1,
+      'vector-storage-integration-test',
+      5,
+      0,
+      'Own sourceType chunk',
+      vectorWith(0, 1, 0),
+    );
+
+    await storeDocumentChunk(
+      1,
+      'some-other-source-type',
+      5,
+      0,
+      'Foreign sourceType chunk, closer vector',
+      vectorWith(1, 0, 0),
+    );
+
+    const results = await searchSimilarChunks(
+      vectorWith(1, 0, 0),
+      undefined,
+      5,
+      'vector-storage-integration-test',
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('Own sourceType chunk');
+
+    await prisma.$executeRaw`
+      DELETE FROM "DocumentChunk"
+      WHERE "sourceType" = 'some-other-source-type'
+    `;
+  });
 });

--- a/tests/integration/vector-storage.integration.test.ts
+++ b/tests/integration/vector-storage.integration.test.ts
@@ -68,6 +68,7 @@ describe('vector storage integration', () => {
       vectorWith(1, 0, 0),
       undefined,
       3,
+      'vector-storage-integration-test',
     );
 
     expect(results).toHaveLength(3);
@@ -112,6 +113,7 @@ describe('vector storage integration', () => {
       vectorWith(1, 0, 0),
       undefined,
       2,
+      'vector-storage-integration-test',
     );
 
     expect(results).toHaveLength(2);
@@ -136,7 +138,12 @@ describe('vector storage integration', () => {
       vectorWith(1, 0, 0),
     );
 
-    const results = await searchSimilarChunks(vectorWith(1, 0, 0), 1, 5);
+    const results = await searchSimilarChunks(
+      vectorWith(1, 0, 0),
+      1,
+      5,
+      'vector-storage-integration-test',
+    );
 
     expect(results).toHaveLength(1);
     expect(results[0].content).toBe('Injury 1 relevant chunk');


### PR DESCRIPTION
Add an optional sourceType filter to searchSimilarChunks so the integration test's queries can be scoped to only the rows it created, preventing spurious failures when unrelated rows share the DocumentChunk table at test time.

Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Similarity searches can now be filtered by source type.
  * Combined injury and source-type filtering improves the relevance of search results.

* **Bug Fixes**
  * Results from unrelated source types are now excluded, even when they have closer vector matches.

* **Tests**
  * Added coverage verifying source-type filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->