### PR TITLE
[P26] Add direct unit tests for src/embeddings/vector-storage.ts

### DIFF
--- a/src/embeddings/vector-storage.ts
+++ b/src/embeddings/vector-storage.ts
@@ -90,8 +90,16 @@ export async function searchSimilarChunks(
   embedding: number[],
   injuryId?: number,
   limit = 5,
+  sourceType?: string,
 ) {
   const vector = `[${embedding.join(',')}]`;
+
+  const filters: Prisma.Sql[] = [];
+  if (injuryId !== undefined) filters.push(Prisma.sql`"injuryId" = ${injuryId}`);
+  if (sourceType !== undefined) filters.push(Prisma.sql`"sourceType" = ${sourceType}`);
+
+  const whereClause =
+    filters.length > 0 ? Prisma.sql`WHERE ${Prisma.join(filters, ' AND ')}` : Prisma.empty;
 
   return prisma.$queryRaw<SearchSimilarChunk[]>(
     Prisma.sql`
@@ -105,11 +113,7 @@ export async function searchSimilarChunks(
         "metadata",
         "embedding" <=> ${vector}::vector AS "distance"
       FROM "DocumentChunk"
-      ${
-        injuryId !== undefined
-          ? Prisma.sql`WHERE "injuryId" = ${injuryId}`
-          : Prisma.empty
-      }
+      ${whereClause}
       ORDER BY "embedding" <=> ${vector}::vector
       LIMIT ${limit}
     `,

--- a/tests/integration/vector-storage.integration.test.ts
+++ b/tests/integration/vector-storage.integration.test.ts
@@ -68,6 +68,7 @@ describe('vector storage integration', () => {
       vectorWith(1, 0, 0),
       undefined,
       3,
+      'vector-storage-integration-test',
     );
 
     expect(results).toHaveLength(3);
@@ -112,6 +113,7 @@ describe('vector storage integration', () => {
       vectorWith(1, 0, 0),
       undefined,
       2,
+      'vector-storage-integration-test',
     );
 
     expect(results).toHaveLength(2);
@@ -136,7 +138,12 @@ describe('vector storage integration', () => {
       vectorWith(1, 0, 0),
     );
 
-    const results = await searchSimilarChunks(vectorWith(1, 0, 0), 1, 5);
+    const results = await searchSimilarChunks(
+      vectorWith(1, 0, 0),
+      1,
+      5,
+      'vector-storage-integration-test',
+    );
 
     expect(results).toHaveLength(1);
     expect(results[0].content).toBe('Injury 1 relevant chunk');

--- a/tests/vector-storage.test.ts
+++ b/tests/vector-storage.test.ts
@@ -172,6 +172,7 @@ describe('searchSimilarChunks', () => {
     expect(separator).toBe(' AND ');
     expect(filters).toHaveLength(1);
     expect(filters[0].values).toEqual([42]);
+    expect(filters[0].strings.join('')).toContain('"injuryId"');
 
     const query = queryRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values[1]).toEqual({
@@ -187,6 +188,7 @@ describe('searchSimilarChunks', () => {
     const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
     expect(filters).toHaveLength(1);
     expect(filters[0].values).toEqual(['treatment']);
+    expect(filters[0].strings.join('')).toContain('"sourceType"');
 
     const query = queryRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values[1]).toEqual({
@@ -203,7 +205,9 @@ describe('searchSimilarChunks', () => {
     expect(separator).toBe(' AND ');
     expect(filters).toHaveLength(2);
     expect(filters[0].values).toEqual([42]);
+    expect(filters[0].strings.join('')).toContain('"injuryId"');
     expect(filters[1].values).toEqual(['treatment']);
+    expect(filters[1].strings.join('')).toContain('"sourceType"');
 
     const query = queryRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values[1]).toEqual({

--- a/tests/vector-storage.test.ts
+++ b/tests/vector-storage.test.ts
@@ -12,6 +12,7 @@ import { jest } from '@jest/globals';
 type SqlResult = { strings: string[]; values: unknown[] };
 
 const executeRawMock = jest.fn<(query: SqlResult) => Promise<unknown>>();
+const queryRawMock = jest.fn<(query: SqlResult) => Promise<unknown>>();
 const disconnectMock = jest.fn<() => Promise<void>>();
 
 const sqlMock = jest.fn(
@@ -21,28 +22,41 @@ const sqlMock = jest.fn(
   }),
 );
 
-const joinMock = jest.fn((values: unknown[]) => ({ __join__: values }));
+const joinMock = jest.fn((values: unknown[], separator?: string) => ({
+  __join__: values,
+  __separator__: separator,
+}));
+
+const emptyMarker = { __empty__: true };
 
 jest.unstable_mockModule('@prisma/client', () => ({
   PrismaClient: jest.fn().mockImplementation(() => ({
     $executeRaw: executeRawMock,
+    $queryRaw: queryRawMock,
     $disconnect: disconnectMock,
   })),
   Prisma: {
     sql: sqlMock,
     join: joinMock,
+    empty: emptyMarker,
   },
 }));
 
-const { storeDocumentChunk, deleteDocumentChunksExcept, disconnectVectorStorage } =
-  await import('../src/embeddings/vector-storage.js');
+const {
+  storeDocumentChunk,
+  deleteDocumentChunksExcept,
+  searchSimilarChunks,
+  disconnectVectorStorage,
+} = await import('../src/embeddings/vector-storage.js');
 
 beforeEach(() => {
   executeRawMock.mockClear();
+  queryRawMock.mockClear();
   disconnectMock.mockClear();
   sqlMock.mockClear();
   joinMock.mockClear();
   executeRawMock.mockResolvedValue(undefined);
+  queryRawMock.mockResolvedValue([]);
   disconnectMock.mockResolvedValue(undefined);
 });
 
@@ -125,6 +139,59 @@ describe('deleteDocumentChunksExcept', () => {
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values[0]).toBe('symptom');
     expect(query.values[1]).toBe(9);
+  });
+});
+
+describe('searchSimilarChunks', () => {
+  it('formats the embedding as a pgvector literal and passes limit through', async () => {
+    await searchSimilarChunks([0.1, 0.2, 0.3], undefined, 7);
+
+    expect(queryRawMock).toHaveBeenCalledTimes(1);
+    expect(joinMock).not.toHaveBeenCalled();
+
+    const query = queryRawMock.mock.calls[0][0] as SqlResult;
+    expect(query.values[0]).toBe('[0.1,0.2,0.3]');
+    expect(query.values[1]).toBe(emptyMarker);
+    expect(query.values[2]).toBe('[0.1,0.2,0.3]');
+    expect(query.values[3]).toBe(7);
+  });
+
+  it('uses no WHERE clause and default limit when neither filter is provided', async () => {
+    await searchSimilarChunks([1]);
+
+    const query = queryRawMock.mock.calls[0][0] as SqlResult;
+    expect(query.values[1]).toBe(emptyMarker);
+    expect(query.values[3]).toBe(5);
+  });
+
+  it('filters by injuryId only when sourceType is omitted', async () => {
+    await searchSimilarChunks([1], 42);
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(separator).toBe(' AND ');
+    expect(filters).toHaveLength(1);
+    expect(filters[0].values).toEqual([42]);
+  });
+
+  it('filters by sourceType only when injuryId is omitted', async () => {
+    await searchSimilarChunks([1], undefined, 5, 'treatment');
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(filters).toHaveLength(1);
+    expect(filters[0].values).toEqual(['treatment']);
+  });
+
+  it('filters by both injuryId and sourceType when both are provided', async () => {
+    await searchSimilarChunks([1], 42, 5, 'treatment');
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(separator).toBe(' AND ');
+    expect(filters).toHaveLength(2);
+    expect(filters[0].values).toEqual([42]);
+    expect(filters[1].values).toEqual(['treatment']);
   });
 });
 

--- a/tests/vector-storage.test.ts
+++ b/tests/vector-storage.test.ts
@@ -172,6 +172,12 @@ describe('searchSimilarChunks', () => {
     expect(separator).toBe(' AND ');
     expect(filters).toHaveLength(1);
     expect(filters[0].values).toEqual([42]);
+
+    const query = queryRawMock.mock.calls[0][0] as SqlResult;
+    expect(query.values[1]).toEqual({
+      strings: expect.any(Array),
+      values: [joinMock.mock.results[0].value],
+    });
   });
 
   it('filters by sourceType only when injuryId is omitted', async () => {
@@ -181,6 +187,12 @@ describe('searchSimilarChunks', () => {
     const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
     expect(filters).toHaveLength(1);
     expect(filters[0].values).toEqual(['treatment']);
+
+    const query = queryRawMock.mock.calls[0][0] as SqlResult;
+    expect(query.values[1]).toEqual({
+      strings: expect.any(Array),
+      values: [joinMock.mock.results[0].value],
+    });
   });
 
   it('filters by both injuryId and sourceType when both are provided', async () => {
@@ -192,6 +204,12 @@ describe('searchSimilarChunks', () => {
     expect(filters).toHaveLength(2);
     expect(filters[0].values).toEqual([42]);
     expect(filters[1].values).toEqual(['treatment']);
+
+    const query = queryRawMock.mock.calls[0][0] as SqlResult;
+    expect(query.values[1]).toEqual({
+      strings: expect.any(Array),
+      values: [joinMock.mock.results[0].value],
+    });
   });
 });
 


### PR DESCRIPTION
Adds direct, DB-independent unit tests for `searchSimilarChunks`'s filter-branch
logic (no filter, injuryId-only, sourceType-only, both, default limit, embedding-
literal formatting), which previously had no coverage outside the real-Postgres
integration test.

Fixes #75