### PR TITLE
test: assert ON CONFLICT SQL structure in storeDocumentChunk unit tests

### DIFF
--- a/tests/vector-storage.test.ts
+++ b/tests/vector-storage.test.ts
@@ -111,6 +111,19 @@ describe('storeDocumentChunk', () => {
     expect(query.values[3]).toBe(4);
     expect(query.values[4]).toBe('chunk body text');
   });
+
+  it('uses the correct ON CONFLICT clause for upserting by (sourceType, sourceId, chunkIndex)', async () => {
+    await storeDocumentChunk(1, 'treatment', 2, 0, 'some content', [0.1, 0.2, 0.3]);
+
+    const query = executeRawMock.mock.calls[0][0] as SqlResult;
+    const sql = query.strings.join('');
+    expect(sql).toContain('ON CONFLICT ("sourceType", "sourceId", "chunkIndex")');
+    expect(sql).toContain('DO UPDATE SET');
+    expect(sql).toContain('"injuryId" = EXCLUDED."injuryId"');
+    expect(sql).toContain('"content" = EXCLUDED."content"');
+    expect(sql).toContain('"embedding" = EXCLUDED."embedding"');
+    expect(sql).toContain('"metadata" = EXCLUDED."metadata"');
+  });
 });
 
 describe('deleteDocumentChunksExcept', () => {


### PR DESCRIPTION
Fixes #76

storeDocumentChunk's unit tests only asserted on bound query values, not
the raw SQL template text, so a regression that dropped or malformed the
ON CONFLICT clause would have passed silently.

Adds one test asserting `query.strings.join('')` contains the ON CONFLICT
clause text, using the same pattern already used for `searchSimilarChunks`
in the same file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying document chunk storage correctly handles conflicts and updates associated chunk data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->