### PR TITLE
feat: build the ingestion worker entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write .",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:integration": "cross-env NODE_ENV=test node --experimental-vm-modules node_modules/jest/bin/jest.js tests/integration --maxWorkers=1",
-    "seed:dev": "tsx prisma/seed-dev.ts"
+    "seed:dev": "tsx prisma/seed-dev.ts",
+    "ingest": "tsx src/ingestion/ingestion-worker.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/src/ingestion/ingestion-worker.ts
+++ b/src/ingestion/ingestion-worker.ts
@@ -3,6 +3,7 @@ import { prisma } from '../lib/prisma.js';
 import { readJournalData } from './reader/postgres-reader.js';
 import { buildJournalDocuments } from './documents/document-builder.js';
 import { embedAndStoreDocument } from './embed-and-store.js';
+import { disconnectVectorStorage } from '../embeddings/vector-storage.js';
 import type { JournalDocument } from './documents/document-types.js';
 
 export interface IngestionFailure {
@@ -109,6 +110,9 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       process.exitCode = 1;
     })
     .finally(async () => {
-      await prisma.$disconnect();
+      // embedAndStoreDocument (via vector-storage.ts) uses its own separate
+      // PrismaClient instance -- disconnect it too, or its connection pool
+      // can keep the process alive after this reports completion.
+      await Promise.all([prisma.$disconnect(), disconnectVectorStorage()]);
     });
 }

--- a/src/ingestion/ingestion-worker.ts
+++ b/src/ingestion/ingestion-worker.ts
@@ -1,0 +1,95 @@
+import { pathToFileURL } from 'node:url';
+import { prisma } from '../lib/prisma.js';
+import { readJournalData } from './reader/postgres-reader.js';
+import { buildJournalDocuments } from './documents/document-builder.js';
+import { embedAndStoreDocument } from './embed-and-store.js';
+import type { JournalDocument } from './documents/document-types.js';
+
+export interface IngestionFailure {
+  sourceType: JournalDocument['metadata']['sourceType'];
+  sourceId: number;
+  injuryId: number;
+  error: unknown;
+}
+
+export interface IngestionResult {
+  total: number;
+  succeeded: number;
+  failed: IngestionFailure[];
+}
+
+/**
+ * Runs one full ingestion pass: reads all journal data, builds documents,
+ * and embeds/stores each document sequentially. A single document failing
+ * does not abort the run -- it is logged and collected in `failed`, and the
+ * run continues, since one bad record should not block ingestion of every
+ * other user's data.
+ *
+ * Each document is stored independently and immediately as it succeeds --
+ * there is no cross-document transaction. A non-empty `failed` array means
+ * a PARTIAL failure, not a rollback: every document counted in `succeeded`
+ * is already durably committed and stays that way regardless of what
+ * happens to documents processed afterward.
+ */
+export async function runIngestion(): Promise<IngestionResult> {
+  const injuries = await readJournalData();
+  const documents = buildJournalDocuments(injuries);
+
+  const result: IngestionResult = {
+    total: documents.length,
+    succeeded: 0,
+    failed: [],
+  };
+
+  for (const document of documents) {
+    try {
+      await embedAndStoreDocument(document);
+      result.succeeded += 1;
+    } catch (error) {
+      console.error(
+        `Ingestion failed for sourceType=${document.metadata.sourceType} ` +
+          `sourceId=${document.metadata.sourceId} injuryId=${document.metadata.injuryId}:`,
+        error,
+      );
+      result.failed.push({
+        sourceType: document.metadata.sourceType,
+        sourceId: document.metadata.sourceId,
+        injuryId: document.metadata.injuryId,
+        error,
+      });
+    }
+  }
+
+  return result;
+}
+
+async function main() {
+  const result = await runIngestion();
+
+  console.log(
+    `Ingestion complete: ${result.succeeded}/${result.total} documents succeeded, ` +
+      `${result.failed.length} failed.`,
+  );
+
+  if (result.failed.length > 0) {
+    throw new Error(
+      `Ingestion completed with ${result.failed.length} of ${result.total} document(s) failed. ` +
+        `This is a PARTIAL failure, not a rollback: the ${result.succeeded} document(s) that ` +
+        `succeeded are already committed to the database. Re-running ingestion is safe -- it will ` +
+        `re-upsert already-succeeded documents (a no-op) and retry the failed ones.`,
+    );
+  }
+}
+
+// Only run as a script (`npm run ingest` / `tsx ingestion-worker.ts`), not
+// when `runIngestion` is imported elsewhere (e.g. by unit tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/src/ingestion/ingestion-worker.ts
+++ b/src/ingestion/ingestion-worker.ts
@@ -21,9 +21,17 @@ export interface IngestionResult {
 /**
  * Runs one full ingestion pass: reads all journal data, builds documents,
  * and embeds/stores each document sequentially. A single document failing
- * does not abort the run -- it is logged and collected in `failed`, and the
- * run continues, since one bad record should not block ingestion of every
- * other user's data.
+ * to embed/store does not abort the run -- it is logged and collected in
+ * `failed`, and the run continues, since one bad record should not block
+ * ingestion of every other user's data.
+ *
+ * `buildJournalDocuments` itself builds every record in one batch call, so a
+ * failure there (e.g. an invalid date) is not attributable to a single
+ * source record -- it is reported as one synthetic `IngestionFailure`
+ * (sourceType 'injury', sourceId/injuryId -1) rather than left as an
+ * unhandled rejection. Isolating this to the specific failing record would
+ * require building documents per-injury instead of in one batch; not done
+ * here to keep this fix minimal (see PR #81 review).
  *
  * Each document is stored independently and immediately as it succeeds --
  * there is no cross-document transaction. A non-empty `failed` array means
@@ -33,7 +41,18 @@ export interface IngestionResult {
  */
 export async function runIngestion(): Promise<IngestionResult> {
   const injuries = await readJournalData();
-  const documents = buildJournalDocuments(injuries);
+
+  let documents: JournalDocument[];
+  try {
+    documents = buildJournalDocuments(injuries);
+  } catch (error) {
+    console.error('Failed to build journal documents for this ingestion run:', error);
+    return {
+      total: 1,
+      succeeded: 0,
+      failed: [{ sourceType: 'injury', sourceId: -1, injuryId: -1, error }],
+    };
+  }
 
   const result: IngestionResult = {
     total: documents.length,
@@ -87,7 +106,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   main()
     .catch((error) => {
       console.error(error);
-      process.exit(1);
+      process.exitCode = 1;
     })
     .finally(async () => {
       await prisma.$disconnect();

--- a/tests/ingestion-worker.test.ts
+++ b/tests/ingestion-worker.test.ts
@@ -1,0 +1,158 @@
+import { jest } from '@jest/globals';
+import type { JournalDocument } from '../src/ingestion/documents/document-types.js';
+import type { InjuryWithRelations } from '../src/ingestion/documents/document-builder.js';
+
+/**
+ * ingestion-worker.ts orchestrates the reader, the document builder, and
+ * embedAndStoreDocument. We mock out all three collaborators so we can
+ * assert on the worker's own sequencing/error-handling logic in isolation
+ * -- in particular, that one document failing does not abort the run.
+ */
+
+const readJournalDataMock =
+  jest.fn<() => Promise<InjuryWithRelations[]>>();
+
+const buildJournalDocumentsMock =
+  jest.fn<(injuries: InjuryWithRelations[]) => JournalDocument[]>();
+
+const embedAndStoreDocumentMock =
+  jest.fn<(document: JournalDocument) => Promise<void>>();
+
+jest.unstable_mockModule('../src/ingestion/reader/postgres-reader.js', () => ({
+  readJournalData: readJournalDataMock,
+}));
+
+jest.unstable_mockModule('../src/ingestion/documents/document-builder.js', () => ({
+  buildJournalDocuments: buildJournalDocumentsMock,
+}));
+
+jest.unstable_mockModule('../src/ingestion/embed-and-store.js', () => ({
+  embedAndStoreDocument: embedAndStoreDocumentMock,
+}));
+
+const { runIngestion } = await import('../src/ingestion/ingestion-worker.js');
+
+function makeDocument(
+  overrides: Partial<JournalDocument['metadata']> = {},
+): JournalDocument {
+  return {
+    content: 'Document content.',
+    metadata: {
+      userId: 1,
+      injuryId: 10,
+      sourceType: 'treatment',
+      sourceId: 100,
+      date: new Date('2025-01-10'),
+      ...overrides,
+    },
+  };
+}
+
+beforeEach(() => {
+  readJournalDataMock.mockReset();
+  buildJournalDocumentsMock.mockReset();
+  embedAndStoreDocumentMock.mockReset();
+
+  readJournalDataMock.mockResolvedValue([]);
+  buildJournalDocumentsMock.mockReturnValue([]);
+});
+
+describe('runIngestion', () => {
+  it('processes every document returned by the builder, in order', async () => {
+    const documents = [
+      makeDocument({ sourceType: 'symptom', sourceId: 1 }),
+      makeDocument({ sourceType: 'treatment', sourceId: 2 }),
+      makeDocument({ sourceType: 'medical_visit', sourceId: 3 }),
+    ];
+
+    readJournalDataMock.mockResolvedValue([{ id: 10 } as InjuryWithRelations]);
+    buildJournalDocumentsMock.mockReturnValue(documents);
+    embedAndStoreDocumentMock.mockResolvedValue(undefined);
+
+    const result = await runIngestion();
+
+    expect(embedAndStoreDocumentMock).toHaveBeenCalledTimes(3);
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(1, documents[0]);
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(2, documents[1]);
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(3, documents[2]);
+
+    expect(result).toEqual({ total: 3, succeeded: 3, failed: [] });
+  });
+
+  it('continues processing after a single document fails, and reports the failure', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const failing = makeDocument({
+      sourceType: 'symptom',
+      sourceId: 1,
+      injuryId: 10,
+    });
+    const documents = [
+      failing,
+      makeDocument({ sourceType: 'treatment', sourceId: 2 }),
+      makeDocument({ sourceType: 'medical_visit', sourceId: 3 }),
+    ];
+
+    buildJournalDocumentsMock.mockReturnValue(documents);
+    const failure = new Error('embed-and-store failed');
+    embedAndStoreDocumentMock
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+
+    const result = await runIngestion();
+
+    expect(embedAndStoreDocumentMock).toHaveBeenCalledTimes(3);
+    expect(result.total).toBe(3);
+    expect(result.succeeded).toBe(2);
+    expect(result.failed).toEqual([
+      {
+        sourceType: 'symptom',
+        sourceId: 1,
+        injuryId: 10,
+        error: failure,
+      },
+    ]);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns an empty result when there is nothing to ingest', async () => {
+    readJournalDataMock.mockResolvedValue([]);
+    buildJournalDocumentsMock.mockReturnValue([]);
+
+    const result = await runIngestion();
+
+    expect(embedAndStoreDocumentMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ total: 0, succeeded: 0, failed: [] });
+  });
+
+  it('accumulates multiple failures without aborting the run', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const documents = [
+      makeDocument({ sourceType: 'symptom', sourceId: 1 }),
+      makeDocument({ sourceType: 'treatment', sourceId: 2 }),
+      makeDocument({ sourceType: 'medical_visit', sourceId: 3 }),
+    ];
+
+    buildJournalDocumentsMock.mockReturnValue(documents);
+    const firstFailure = new Error('first failure');
+    const secondFailure = new Error('second failure');
+    embedAndStoreDocumentMock
+      .mockRejectedValueOnce(firstFailure)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(secondFailure);
+
+    const result = await runIngestion();
+
+    expect(embedAndStoreDocumentMock).toHaveBeenCalledTimes(3);
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toHaveLength(2);
+    expect(result.failed[0]).toMatchObject({ sourceId: 1, error: firstFailure });
+    expect(result.failed[1]).toMatchObject({ sourceId: 3, error: secondFailure });
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/ingestion-worker.test.ts
+++ b/tests/ingestion-worker.test.ts
@@ -128,6 +128,28 @@ describe('runIngestion', () => {
     expect(result).toEqual({ total: 0, succeeded: 0, failed: [] });
   });
 
+  it('reports a single synthetic failure and does not throw when buildJournalDocuments fails', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    readJournalDataMock.mockResolvedValue([{ id: 10 } as InjuryWithRelations]);
+    const buildFailure = new Error('invalid date');
+    buildJournalDocumentsMock.mockImplementation(() => {
+      throw buildFailure;
+    });
+
+    const result = await runIngestion();
+
+    expect(embedAndStoreDocumentMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      total: 1,
+      succeeded: 0,
+      failed: [{ sourceType: 'injury', sourceId: -1, injuryId: -1, error: buildFailure }],
+    });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it('accumulates multiple failures without aborting the run', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 


### PR DESCRIPTION
## Summary
- Adds `src/ingestion/ingestion-worker.ts`, wiring the existing reader -> document-builder -> `embedAndStoreDocument` stages into a runnable entrypoint (`npm run ingest`), since nothing previously drove the pipeline end-to-end outside tests.
- Processes documents sequentially; a single document failing is logged with `sourceType`/`sourceId`/`injuryId` context and collected, not aborted -- the run continues and reports partial failure via a non-zero exit code, without rolling back documents that already succeeded.
- Adds unit test coverage (`tests/ingestion-worker.test.ts`): happy path, single-document failure/continue-on-error, empty result, multiple failures.

Closes #40.

Stacked on #80 (76-assert-on-conflict-sql) -- diff will narrow once that merges.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (39 suites / 178 tests, includes integration tests)
- [x] Manual end-to-end: ran `npm run ingest` against local dev DB + embedding service -- 22/22 documents ingested, `DocumentChunk` went from 1 -> 22 rows
- [x] Re-ran the evaluation harness before/after ingestion; 2 pre-existing retrieval-eval failures confirmed unrelated to this change (stale `sourceId` in `evaluation/ai-system/dataset.json`, not caused by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an ingestion command to process journal data and store generated document embeddings.
  - Ingestion now reports total, successful, and failed document counts.
  - Individual document failures are recorded while processing continues for remaining documents.
  - Clear error reporting is provided when an ingestion run completes with partial failures.

- **Reliability**
  - Added safeguards to ensure resources are properly disconnected after ingestion completes or encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->