### PR TITLE
feat: add an indexed userId column on DocumentChunk (#41)

### DIFF
--- a/prisma/migrations/20260827032413_add_document_chunk_userid/migration.sql
+++ b/prisma/migrations/20260827032413_add_document_chunk_userid/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Backfill userId before making it NOT NULL.
+
+  DocumentChunk.userId is denormalized from Injury.userId so that
+  chunks can be filtered/indexed by user directly, without joining
+  through Injury on every query.
+*/
+
+-- Add the column as nullable first.
+ALTER TABLE "DocumentChunk"
+ADD COLUMN "userId" INTEGER;
+
+-- Backfill from the existing injuryId -> Injury.userId relationship.
+UPDATE "DocumentChunk" AS dc
+SET "userId" = i."userId"
+FROM "Injury" AS i
+WHERE i.id = dc."injuryId";
+
+-- Now that every existing row has a value, make it required.
+ALTER TABLE "DocumentChunk"
+ALTER COLUMN "userId" SET NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "DocumentChunk_userId_idx" ON "DocumentChunk"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,7 @@ model User {
 model DocumentChunk {
   id          Int      @id @default(autoincrement())
   injuryId    Int
+  userId      Int
   sourceType  String
   sourceId    Int
   chunkIndex  Int
@@ -105,6 +106,7 @@ model DocumentChunk {
   Injury Injury @relation(fields: [injuryId], references: [id])
 
   @@index([injuryId])
+  @@index([userId])
   @@index([sourceType, sourceId])
   @@unique([sourceType, sourceId, chunkIndex])
 }

--- a/src/embeddings/vector-storage.ts
+++ b/src/embeddings/vector-storage.ts
@@ -6,6 +6,7 @@ type SearchSimilarChunk = Pick<
   Prisma.DocumentChunkGetPayload<Prisma.DocumentChunkDefaultArgs>,
   | 'id'
   | 'injuryId'
+  | 'userId'
   | 'sourceType'
   | 'sourceId'
   | 'chunkIndex'
@@ -20,6 +21,7 @@ export async function disconnectVectorStorage() {
 
 export async function storeDocumentChunk(
   injuryId: number,
+  userId: number,
   sourceType: string,
   sourceId: number,
   chunkIndex: number,
@@ -33,6 +35,7 @@ export async function storeDocumentChunk(
     Prisma.sql`
       INSERT INTO "DocumentChunk" (
         "injuryId",
+        "userId",
         "sourceType",
         "sourceId",
         "chunkIndex",
@@ -42,6 +45,7 @@ export async function storeDocumentChunk(
       )
       VALUES (
         ${injuryId},
+        ${userId},
         ${sourceType},
         ${sourceId},
         ${chunkIndex},
@@ -52,6 +56,7 @@ export async function storeDocumentChunk(
       ON CONFLICT ("sourceType", "sourceId", "chunkIndex")
       DO UPDATE SET
         "injuryId" = EXCLUDED."injuryId",
+        "userId" = EXCLUDED."userId",
         "content" = EXCLUDED."content",
         "embedding" = EXCLUDED."embedding",
         "metadata" = EXCLUDED."metadata"
@@ -91,12 +96,14 @@ export async function searchSimilarChunks(
   injuryId?: number,
   limit = 5,
   sourceType?: string,
+  userId?: number,
 ) {
   const vector = `[${embedding.join(',')}]`;
 
   const filters: Prisma.Sql[] = [];
   if (injuryId !== undefined) filters.push(Prisma.sql`"injuryId" = ${injuryId}`);
   if (sourceType !== undefined) filters.push(Prisma.sql`"sourceType" = ${sourceType}`);
+  if (userId !== undefined) filters.push(Prisma.sql`"userId" = ${userId}`);
 
   const whereClause =
     filters.length > 0 ? Prisma.sql`WHERE ${Prisma.join(filters, ' AND ')}` : Prisma.empty;
@@ -106,6 +113,7 @@ export async function searchSimilarChunks(
       SELECT
         "id",
         "injuryId",
+        "userId",
         "sourceType",
         "sourceId",
         "chunkIndex",

--- a/src/ingestion/embed-and-store.ts
+++ b/src/ingestion/embed-and-store.ts
@@ -33,6 +33,7 @@ export async function embedAndStoreDocument(
 
         await storeDocumentChunk(
           embeddedDocument.document.metadata.injuryId,
+          embeddedDocument.document.metadata.userId,
           embeddedDocument.document.metadata.sourceType,
           embeddedDocument.document.metadata.sourceId,
           chunkIndex,

--- a/tests/embed-and-store.test.ts
+++ b/tests/embed-and-store.test.ts
@@ -33,6 +33,7 @@ const storeDocumentChunkMock =
   jest.fn<
     (
       injuryId: number,
+      userId: number,
       sourceType: string,
       sourceId: number,
       chunkIndex: number,
@@ -145,6 +146,7 @@ describe('embedAndStoreDocument', () => {
     expect(storeDocumentChunkMock).toHaveBeenNthCalledWith(
       1,
       document.metadata.injuryId,
+      document.metadata.userId,
       document.metadata.sourceType,
       document.metadata.sourceId,
       0,
@@ -163,6 +165,7 @@ describe('embedAndStoreDocument', () => {
     expect(storeDocumentChunkMock).toHaveBeenNthCalledWith(
       2,
       document.metadata.injuryId,
+      document.metadata.userId,
       document.metadata.sourceType,
       document.metadata.sourceId,
       1,

--- a/tests/integration/ai-agent-route.integration.test.ts
+++ b/tests/integration/ai-agent-route.integration.test.ts
@@ -41,6 +41,7 @@ describe('AI agent route integration', () => {
 
     await storeDocumentChunk(
       injuryId,
+      userId,
       'ai-agent-integration-test',
       1,
       0,

--- a/tests/integration/document-chunk-userid-backfill.integration.test.ts
+++ b/tests/integration/document-chunk-userid-backfill.integration.test.ts
@@ -1,0 +1,69 @@
+import { prisma } from '../../src/lib/prisma.js';
+import { createTestInjury, deleteTestInjury } from './test-injury-fixuture.js';
+
+/**
+ * Exercises the exact backfill logic from
+ * prisma/migrations/20260827032413_add_document_chunk_userid/migration.sql
+ * against a row that predates the userId column (i.e. one inserted with
+ * userId unset), since that migration has only ever run against databases
+ * with zero pre-existing DocumentChunk rows and its backfill UPDATE has
+ * never actually been exercised.
+ */
+describe('DocumentChunk userId backfill migration', () => {
+  let injuryId: number;
+  let userId: number;
+
+  beforeAll(async () => {
+    const testInjury = await createTestInjury('Backfill Migration Test');
+    injuryId = testInjury.injuryId;
+    userId = testInjury.userId;
+  });
+
+  afterAll(async () => {
+    await deleteTestInjury(injuryId, userId);
+  });
+
+  it('derives userId from Injury.userId for a pre-existing row with no userId set', async () => {
+    // Temporarily relax the NOT NULL constraint to simulate a row that
+    // predates the userId column, then insert it with userId left NULL.
+    await prisma.$executeRaw`
+      ALTER TABLE "DocumentChunk" ALTER COLUMN "userId" DROP NOT NULL
+    `;
+
+    let chunkId: number;
+    try {
+      const inserted = await prisma.$queryRaw<{ id: number }[]>`
+        INSERT INTO "DocumentChunk" (
+          "injuryId", "sourceType", "sourceId", "chunkIndex", "content"
+        )
+        VALUES (
+          ${injuryId}, 'backfill-migration-test', 1, 0, 'pre-existing chunk'
+        )
+        RETURNING "id"
+      `;
+      chunkId = inserted[0].id;
+
+      // Run the same backfill statement the migration uses.
+      await prisma.$executeRaw`
+        UPDATE "DocumentChunk" AS dc
+        SET "userId" = i."userId"
+        FROM "Injury" AS i
+        WHERE i.id = dc."injuryId"
+          AND dc."id" = ${chunkId}
+      `;
+
+      const [row] = await prisma.$queryRaw<{ userId: number }[]>`
+        SELECT "userId" FROM "DocumentChunk" WHERE "id" = ${chunkId}
+      `;
+
+      expect(row.userId).toBe(userId);
+    } finally {
+      await prisma.$executeRaw`
+        DELETE FROM "DocumentChunk" WHERE "sourceType" = 'backfill-migration-test'
+      `;
+      await prisma.$executeRaw`
+        ALTER TABLE "DocumentChunk" ALTER COLUMN "userId" SET NOT NULL
+      `;
+    }
+  });
+});

--- a/tests/integration/rag-pipeline.integration.test.ts
+++ b/tests/integration/rag-pipeline.integration.test.ts
@@ -40,6 +40,7 @@ describe('RAG pipeline integration', () => {
 
     await storeDocumentChunk(
       injuryId,
+      userId,
       'rag-pipeline-integration-test',
       1,
       0,
@@ -49,6 +50,7 @@ describe('RAG pipeline integration', () => {
 
     await storeDocumentChunk(
       injuryId,
+      userId,
       'rag-pipeline-integration-test',
       1,
       1,

--- a/tests/integration/rag-route.integration.test.ts
+++ b/tests/integration/rag-route.integration.test.ts
@@ -49,6 +49,7 @@ describe('RAG route integration', () => {
 
     await storeDocumentChunk(
       injuryId,
+      userId,
       'rag-route-integration-test',
       1,
       0,
@@ -58,6 +59,7 @@ describe('RAG route integration', () => {
 
     await storeDocumentChunk(
       injuryId,
+      userId,
       'rag-route-integration-test',
       1,
       1,
@@ -67,6 +69,7 @@ describe('RAG route integration', () => {
 
     await storeDocumentChunk(
       otherInjuryId,
+      otherUserId,
       'rag-route-integration-test',
       2,
       0,

--- a/tests/integration/vector-storage.integration.test.ts
+++ b/tests/integration/vector-storage.integration.test.ts
@@ -39,6 +39,7 @@ describe('vector storage integration', () => {
   it('retrieves chunks ordered by cosine similarity', async () => {
     await storeDocumentChunk(
       1,
+      1,
       'vector-storage-integration-test',
       1,
       0,
@@ -48,6 +49,7 @@ describe('vector storage integration', () => {
 
     await storeDocumentChunk(
       1,
+      1,
       'vector-storage-integration-test',
       1,
       1,
@@ -56,6 +58,7 @@ describe('vector storage integration', () => {
     );
 
     await storeDocumentChunk(
+      1,
       1,
       'vector-storage-integration-test',
       1,
@@ -84,6 +87,7 @@ describe('vector storage integration', () => {
   it('respects the result limit', async () => {
     await storeDocumentChunk(
       1,
+      1,
       'vector-storage-integration-test',
       2,
       0,
@@ -93,6 +97,7 @@ describe('vector storage integration', () => {
 
     await storeDocumentChunk(
       1,
+      1,
       'vector-storage-integration-test',
       2,
       1,
@@ -101,6 +106,7 @@ describe('vector storage integration', () => {
     );
 
     await storeDocumentChunk(
+      1,
       1,
       'vector-storage-integration-test',
       2,
@@ -122,6 +128,7 @@ describe('vector storage integration', () => {
   it('filters results by injuryId when provided', async () => {
     await storeDocumentChunk(
       1,
+      1,
       'vector-storage-integration-test',
       3,
       0,
@@ -130,6 +137,7 @@ describe('vector storage integration', () => {
     );
 
     await storeDocumentChunk(
+      2,
       2,
       'vector-storage-integration-test',
       4,
@@ -150,8 +158,43 @@ describe('vector storage integration', () => {
     expect(results[0].injuryId).toBe(1);
   });
 
+  it('filters results by userId when provided', async () => {
+    await storeDocumentChunk(
+      1,
+      1,
+      'vector-storage-integration-test',
+      6,
+      0,
+      'User 1 relevant chunk',
+      vectorWith(1, 0, 0),
+    );
+
+    await storeDocumentChunk(
+      2,
+      2,
+      'vector-storage-integration-test',
+      7,
+      0,
+      'User 2 relevant chunk',
+      vectorWith(1, 0, 0),
+    );
+
+    const results = await searchSimilarChunks(
+      vectorWith(1, 0, 0),
+      undefined,
+      5,
+      'vector-storage-integration-test',
+      1,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('User 1 relevant chunk');
+    expect(results[0].userId).toBe(1);
+  });
+
   it('excludes rows from a different sourceType even when their vector is closer', async () => {
     await storeDocumentChunk(
+      1,
       1,
       'vector-storage-integration-test',
       5,
@@ -161,6 +204,7 @@ describe('vector storage integration', () => {
     );
 
     await storeDocumentChunk(
+      1,
       1,
       'some-other-source-type',
       5,

--- a/tests/vector-storage.test.ts
+++ b/tests/vector-storage.test.ts
@@ -62,13 +62,14 @@ beforeEach(() => {
 
 describe('storeDocumentChunk', () => {
   it('inserts a document chunk with the embedding formatted as a pgvector literal', async () => {
-    await storeDocumentChunk(1, 'treatment', 2, 0, 'some content', [0.1, 0.2, 0.3]);
+    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'some content', [0.1, 0.2, 0.3]);
 
     expect(executeRawMock).toHaveBeenCalledTimes(1);
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values).toEqual([
       1,
+      9,
       'treatment',
       2,
       0,
@@ -79,47 +80,56 @@ describe('storeDocumentChunk', () => {
   });
 
   it('serializes metadata to JSON when provided', async () => {
-    await storeDocumentChunk(1, 'treatment', 2, 0, 'content', [0.1], {
+    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'content', [0.1], {
       foo: 'bar',
     });
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[6]).toBe(JSON.stringify({ foo: 'bar' }));
+    expect(query.values[7]).toBe(JSON.stringify({ foo: 'bar' }));
   });
 
   it('uses null metadata when none is provided', async () => {
-    await storeDocumentChunk(1, 'treatment', 2, 0, 'content', [0.1]);
+    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'content', [0.1]);
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[6]).toBeNull();
+    expect(query.values[7]).toBeNull();
   });
 
   it('formats an empty embedding array as an empty vector literal', async () => {
-    await storeDocumentChunk(1, 'treatment', 2, 0, 'content', []);
+    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'content', []);
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[5]).toBe('[]');
+    expect(query.values[6]).toBe('[]');
   });
 
   it('passes the chunkIndex and content through unchanged', async () => {
-    await storeDocumentChunk(7, 'medical_visit', 3, 4, 'chunk body text', [1]);
+    await storeDocumentChunk(7, 9, 'medical_visit', 3, 4, 'chunk body text', [1]);
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values[0]).toBe(7);
-    expect(query.values[1]).toBe('medical_visit');
-    expect(query.values[2]).toBe(3);
-    expect(query.values[3]).toBe(4);
-    expect(query.values[4]).toBe('chunk body text');
+    expect(query.values[1]).toBe(9);
+    expect(query.values[2]).toBe('medical_visit');
+    expect(query.values[3]).toBe(3);
+    expect(query.values[4]).toBe(4);
+    expect(query.values[5]).toBe('chunk body text');
+  });
+
+  it('passes the userId through unchanged', async () => {
+    await storeDocumentChunk(1, 42, 'treatment', 2, 0, 'content', [0.1]);
+
+    const query = executeRawMock.mock.calls[0][0] as SqlResult;
+    expect(query.values[1]).toBe(42);
   });
 
   it('uses the correct ON CONFLICT clause for upserting by (sourceType, sourceId, chunkIndex)', async () => {
-    await storeDocumentChunk(1, 'treatment', 2, 0, 'some content', [0.1, 0.2, 0.3]);
+    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'some content', [0.1, 0.2, 0.3]);
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
     const sql = query.strings.join('');
     expect(sql).toContain('ON CONFLICT ("sourceType", "sourceId", "chunkIndex")');
     expect(sql).toContain('DO UPDATE SET');
     expect(sql).toContain('"injuryId" = EXCLUDED."injuryId"');
+    expect(sql).toContain('"userId" = EXCLUDED."userId"');
     expect(sql).toContain('"content" = EXCLUDED."content"');
     expect(sql).toContain('"embedding" = EXCLUDED."embedding"');
     expect(sql).toContain('"metadata" = EXCLUDED."metadata"');
@@ -227,6 +237,37 @@ describe('searchSimilarChunks', () => {
       strings: expect.any(Array),
       values: [joinMock.mock.results[0].value],
     });
+  });
+
+  it('filters by userId only when injuryId and sourceType are omitted', async () => {
+    await searchSimilarChunks([1], undefined, 5, undefined, 42);
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(filters).toHaveLength(1);
+    expect(filters[0].values).toEqual([42]);
+    expect(filters[0].strings.join('')).toContain('"userId"');
+
+    const query = queryRawMock.mock.calls[0][0] as SqlResult;
+    expect(query.values[1]).toEqual({
+      strings: expect.any(Array),
+      values: [joinMock.mock.results[0].value],
+    });
+  });
+
+  it('filters by injuryId, sourceType, and userId together when all are provided', async () => {
+    await searchSimilarChunks([1], 42, 5, 'treatment', 7);
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(separator).toBe(' AND ');
+    expect(filters).toHaveLength(3);
+    expect(filters[0].values).toEqual([42]);
+    expect(filters[0].strings.join('')).toContain('"injuryId"');
+    expect(filters[1].values).toEqual(['treatment']);
+    expect(filters[1].strings.join('')).toContain('"sourceType"');
+    expect(filters[2].values).toEqual([7]);
+    expect(filters[2].strings.join('')).toContain('"userId"');
   });
 });
 


### PR DESCRIPTION
Denormalizes userId from Injury.userId onto DocumentChunk so retrieval can filter/index by user directly instead of relying on the unindexed metadata JSON blob, unblocking #31's authorization work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document chunks now retain their associated user information.
  * Similar-document searches can be filtered by user for more targeted results.
  * Existing document data is automatically updated to include ownership details.

* **Tests**
  * Added coverage for user-specific search filtering, data migration, and ownership preservation across the document processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->