### PR TITLE
docs: record decision that this backend does not own journal CRUD + auth

### DIFF
--- a/docs/01-product.md
+++ b/docs/01-product.md
@@ -26,13 +26,14 @@ Injury Journal AI is an AI-powered assistant that helps users search, understand
 
 It works on top of an existing Injury Journal application and uses structured journal data — including injuries, symptoms, treatments, medical visits, and timeline events — as its source of truth.
 
-> **Scope clarification (added during the `docs/handoff/` review series):** this backend does
-> not implement journal record creation/editing or user authentication — those are assumed to be
-> owned by that existing Injury Journal application. Today, this repo exposes only one AI
-> endpoint (`POST /ai-agent`); there is no `GET /injuries`, no way to create or
-> edit a record, and no login. If a frontend is meant to be built against this backend for
-> anything beyond asking questions, that scope needs to be decided explicitly and is not yet.
-> See `docs/05-api-contract.md` §6.
+> **Scope decision (resolved via issue #49):** this backend does not implement journal record
+> creation/editing or user authentication/session issuance — a separate, existing Injury Journal
+> application owns both. This repo remains read-only/AI-only against journal data it ingests from
+> that application. Today, this repo exposes only one AI endpoint (`POST /ai-agent`); there is no
+> `GET /injuries`, no way to create or edit a record, and no login, and none of those are planned
+> for this repo. The practical implication for authentication (issue #94): this backend will
+> eventually verify tokens/sessions issued by that other application, not issue its own. See
+> `docs/05-api-contract.md` §6 and `docs/02-architecture.md` §11 (Decision D10).
 
 The system uses embeddings, semantic retrieval, RAG, and eventually AI agents to produce grounded answers and summaries.
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -673,3 +673,23 @@ quoted), what else was considered, whether it still holds, and whether it should
   results until that column is added." This is a schema migration, not just application code.
 - **SHOULD THIS BE REVISITED:** Yes — already tracked (issue #41) and correctly sequenced ahead of
   the broader authorization work (#31), since #31 depends on it.
+
+### D10 — This backend does not own journal CRUD or authentication; a separate app does
+
+- **DECISION:** This backend does not own `Injury` CRUD or authentication/session issuance; a
+  separate existing Injury Journal application owns both. This repo remains AI/RAG/agent-only,
+  consuming journal data as its source of truth and (once #94 lands) verifying identity via
+  tokens/sessions issued by that other application rather than minting its own.
+- **RATIONALE:** Decided directly with the project owner while resolving issue #49; keeps this
+  repo's scope aligned with its stated purpose (AI assistant on top of an existing journal app,
+  per `docs/01-product.md` §1) rather than growing into a second product surface.
+- **ALTERNATIVES CONSIDERED:** This backend owns CRUD + auth end-to-end — rejected as unnecessary
+  scope growth for a project whose value is the AI layer, not journal record-keeping.
+- **CURRENT STATUS:** Decided (issue #49). Downstream: #94 should be scoped as "verify
+  externally-issued tokens/sessions," not "build login/session issuance." #50 (`[P10]` journal
+  CRUD + auth endpoints) and #51 (`[P11]` conversation/thread concept) stay out of this repo's
+  scope under this decision; re-scoping or closing those issues is separate follow-up work, not
+  part of this decision itself.
+- **SHOULD THIS BE REVISITED:** Only if the "existing Injury Journal application" assumption turns
+  out to be wrong (e.g. no such external app actually exists yet) — not expected based on the
+  current product description.

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -28,7 +28,8 @@ truth for status; the issues are. Re-sync this file whenever a linked issue's st
 
 ### Open / Not Started
 
-- [ ] Step 5 — Security and Production Hardening (#31)
+- [ ] Step 5 — Security and Production Hardening (#31, closed — decomposed into #89-#99; see
+  "Step 5 security" below)
 - [ ] Step 6 — AI Observability + AI-Assisted Observability (#32)
 - [ ] Step 7 — Production Workflow with AWS (#33)
 - [ ] Step 8 — Infrastructure as Code (#34)
@@ -58,7 +59,7 @@ issue number, or marked "not yet filed" where none exists yet.
   `JSON.stringify(injury)` inside a prose `answer` field; now returns an LLM-generated prose
   summary of the injury record. (#38)
 - [ ] Add a real, indexed `userId` column on `DocumentChunk` (denormalized from `Injury.userId`
-  at write time). This is a schema migration, and #31's authorization work depends on it existing
+  at write time). This is a schema migration, and #95's authorization work depends on it existing
   first — today `userId` only lives inside an unindexed JSON blob and cannot be filtered on. (#41)
 - [ ] Start threading a request ID through the pipeline now, even as a no-op passed-through
   parameter, rather than retrofitting it into every function signature once #32 starts. (#42)
@@ -66,20 +67,41 @@ issue number, or marked "not yet filed" where none exists yet.
   the LLM actually do with an empty context block?). Likely the common case until the ingestion
   worker above exists. (#39)
 
-**Fold into Step 5 / #31 (security), more concretely scoped than the current issue text:**
+**Step 5 security (formerly the single epic #31, now closed and decomposed into 11 scoped
+issues — a security gap-analysis pass also surfaced items #31's own text never named):**
 
-- [ ] Authentication + session/identity on every request (currently: zero — every request is
-  anonymous server-side). (#31)
-- [ ] Per-tool authorization step in the agent orchestrator — does not exist today, not even
-  partially. (#31)
+*Urgent (no dependencies, do first):*
+- [ ] Add rate limiting to prevent LLM/embedding cost-abuse and resource exhaustion — confirmed
+  exploitable today (no auth, no rate limit, every request triggers a paid Groq + embedding call). (#89)
+- [ ] Add schema-based request input validation (Zod) incl. a max question length. (#90)
+- [ ] Regression tests for data isolation boundaries — currently zero tests exist proving
+  cross-user chunk leakage can't happen when `injuryId` is omitted (requested explicitly in #31's
+  own text). (#91)
+- [ ] Redact/minimize sensitive data in error logging (`console.error` catch blocks) — a present-day
+  leak risk, distinct from and not gated on #32's larger future AWS observability project. (#92)
+
+*Normal priority:*
+- [ ] Ensure the app's Postgres role follows least privilege + document DB connection hygiene. (#93)
+- [ ] Authentication + session/identity on every request (currently: zero) — blocked on #49
+  (does this backend own auth, or verify tokens from a separate app?). (#94)
+- [ ] Per-tool + retrieval/vector-level authorization enforcing user-level data isolation — depends
+  on #94. (#95)
+- [ ] Output-side safety check — the current safety layer is entirely pre-generation; nothing
+  checks whether the LLM's answer echoes diagnosis-adjacent language from a chunk's raw content. (#96)
+
+*Optional (safe to defer indefinitely):*
+- [ ] Add helmet + CORS security headers — low value until a real deployed origin/frontend exists. (#97)
+- [ ] Add `npm audit`/Dependabot/SCA scanning to CI. (#98)
+- [ ] Document third-party LLM data exposure (Groq) and the embedding service's missing auth
+  boundary as accepted risks. (#99)
+
+*Deliberately not duplicated:* safe logging → already tracked under #32 ([P19] AI Observability);
+least-privilege IAM (AWS roles/policies) and secret rotation → already tracked under #34 ([P21]
+Infrastructure as Code) — both are cloud-infra concepts with no local-codebase equivalent today.
+
 - [x] `POST /rag/ask` retired; `POST /ai-agent` is the sole public entrypoint. `answerQuestion()`
   stays as an internal function (`ragTool` already called it directly). Resolves the divergent
   `injuryId` validation by elimination rather than reconciliation. (#43)
-- [ ] Regression tests for data isolation boundaries specifically (requested explicitly in #31's
-  own text) — currently zero tests exist proving cross-user chunk leakage can't happen when
-  `injuryId` is omitted. (#31)
-- [ ] Output-side safety check — the current safety layer is entirely pre-generation; nothing
-  checks whether the LLM's answer echoes diagnosis-adjacent language from a chunk's raw content. (#31)
 
 **Fold into Step 9 backlog cleanup / general hygiene (not urgent, but shouldn't be lost):**
 


### PR DESCRIPTION
## Summary
- Resolves issue sabrahermassi/injury-journal-ai#49: a separate existing Injury Journal application owns journal CRUD and authentication/session issuance; this backend stays read-only/AI-only.
- Updates `docs/01-product.md` §1 to reflect the decided scope (was previously an open question).
- Adds Decision D10 to `docs/02-architecture.md`'s architectural decision log, following the existing D1–D9 template, including the downstream implication for sabrahermassi/injury-journal-ai#94 (verify externally-issued tokens, don't build login) and noting sabrahermassi/injury-journal-ai#50/#51 stay out of this repo's scope.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (38 suites / 173 tests passing)
- Docs-only change; no evaluation harness or integration tests required.

Fixes sabrahermassi/injury-journal-ai#49