### PR TITLE
chore: consolidate PrismaClient instantiation behind src/lib/prisma.ts

### DIFF
--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -111,8 +111,9 @@ Infrastructure as Code) — both are cloud-infra concepts with no local-codebase
   `citation-formatter.ts`, `citation-source-mapper.ts`) — either wire them into the response path
   as #35 already plans, or remove them; two of the three only handle 2 of 5 valid `sourceType`
   values (`treatment`, `medical_visit` — missing `symptom`, `timeline_event`, `injury`). (not yet filed)
-- [ ] Consolidate `PrismaClient` instantiation behind `src/lib/prisma.ts` — four files construct
-  their own client independently today. (#47)
+- [x] Consolidate `PrismaClient` instantiation behind `src/lib/prisma.ts` — the four files that
+  previously constructed their own client (`vector-storage.ts`, `journal-tool.ts`,
+  `citation-verifier.ts`, `citation-source-mapper.ts`) now import the shared singleton. (#47)
 - [x] Add `journal-tool.ts` test coverage — both `journalTool()` and `formatInjuryRecord()` are now
   covered in `tests/journal-tool.test.ts`. (#44)
 - [ ] Surface `AgentState.intent` in the actual HTTP response — it's computed, tracked, and then

--- a/src/ai-agent/tools/journal-tool.ts
+++ b/src/ai-agent/tools/journal-tool.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { prisma } from '../../lib/prisma.js';
 
 export async function journalTool(injuryId: number, requestId?: string) {
   void requestId; // unused for now — reserved for future log correlation (#32)

--- a/src/embeddings/vector-storage.ts
+++ b/src/embeddings/vector-storage.ts
@@ -1,6 +1,5 @@
-import { PrismaClient, Prisma } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { Prisma } from '@prisma/client';
+import { prisma } from '../lib/prisma.js';
 
 type SearchSimilarChunk = Pick<
   Prisma.DocumentChunkGetPayload<Prisma.DocumentChunkDefaultArgs>,

--- a/src/ingestion/ingestion-worker.ts
+++ b/src/ingestion/ingestion-worker.ts
@@ -3,7 +3,6 @@ import { prisma } from '../lib/prisma.js';
 import { readJournalData } from './reader/postgres-reader.js';
 import { buildJournalDocuments } from './documents/document-builder.js';
 import { embedAndStoreDocument } from './embed-and-store.js';
-import { disconnectVectorStorage } from '../embeddings/vector-storage.js';
 import type { JournalDocument } from './documents/document-types.js';
 
 export interface IngestionFailure {
@@ -110,9 +109,6 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       process.exitCode = 1;
     })
     .finally(async () => {
-      // embedAndStoreDocument (via vector-storage.ts) uses its own separate
-      // PrismaClient instance -- disconnect it too, or its connection pool
-      // can keep the process alive after this reports completion.
-      await Promise.all([prisma.$disconnect(), disconnectVectorStorage()]);
+      await prisma.$disconnect();
     });
 }

--- a/src/rag/citation-source-mapper.ts
+++ b/src/rag/citation-source-mapper.ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '../lib/prisma.js';
 import type { Citation } from './citation-builder.js';
-
-const prisma = new PrismaClient();
 
 export async function mapCitationSources(
   citations: Array<Pick<Citation, 'sourceType' | 'sourceId'>>,

--- a/src/rag/citation-verifier.ts
+++ b/src/rag/citation-verifier.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { prisma } from '../lib/prisma.js';
 
 export async function verifyCitations(
   citations: Array<{


### PR DESCRIPTION
## Summary
- `vector-storage.ts`, `journal-tool.ts`, `citation-verifier.ts`, and `citation-source-mapper.ts` each constructed their own `PrismaClient` independently — they now import the shared singleton from `src/lib/prisma.ts` (already used by the ingestion pipeline).
- `ingestion-worker.ts`'s shutdown `finally` block previously disconnected two clients under a comment claiming they were separate instances; simplified to a single `prisma.$disconnect()` now that they share the client.
- Checked off #47 in `docs/04-implementation-roadmap.md`.

Purely a dependency-injection change — no behavior change, no new logic or branches.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — 173/173 passing

Fixes #47