### PR TITLE
chore: consolidate PrismaClient instantiation behind src/lib/prisma.ts

### DIFF
--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -107,12 +107,13 @@ Infrastructure as Code) — both are cloud-infra concepts with no local-codebase
 
 - [ ] Delete or finish `src/ai-agent/ai-agent-service.ts` — a second, unused, partially-dead
   duplicate of `ai-agent-orchestrator.ts`. (#46)
+- [x] Consolidate `PrismaClient` instantiation behind `src/lib/prisma.ts` — `vector-storage.ts`,
+  `journal-tool.ts`, `citation-source-mapper.ts`, and `citation-verifier.ts` now import the shared
+  singleton instead of each constructing their own client. (#47)
 - [ ] Resolve the three unwired citation modules (`citation-verifier.ts`,
   `citation-formatter.ts`, `citation-source-mapper.ts`) — either wire them into the response path
   as #35 already plans, or remove them; two of the three only handle 2 of 5 valid `sourceType`
   values (`treatment`, `medical_visit` — missing `symptom`, `timeline_event`, `injury`). (not yet filed)
-- [ ] Consolidate `PrismaClient` instantiation behind `src/lib/prisma.ts` — four files construct
-  their own client independently today. (#47)
 - [x] Add `journal-tool.ts` test coverage — both `journalTool()` and `formatInjuryRecord()` are now
   covered in `tests/journal-tool.test.ts`. (#44)
 - [ ] Surface `AgentState.intent` in the actual HTTP response — it's computed, tracked, and then

--- a/src/ai-agent/tools/journal-tool.ts
+++ b/src/ai-agent/tools/journal-tool.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { prisma } from '../../lib/prisma.js';
 
 export async function journalTool(injuryId: number, requestId?: string) {
   void requestId; // unused for now — reserved for future log correlation (#32)

--- a/src/embeddings/vector-storage.ts
+++ b/src/embeddings/vector-storage.ts
@@ -1,6 +1,5 @@
-import { PrismaClient, Prisma } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { Prisma } from '@prisma/client';
+import { prisma } from '../lib/prisma.js';
 
 type SearchSimilarChunk = Pick<
   Prisma.DocumentChunkGetPayload<Prisma.DocumentChunkDefaultArgs>,

--- a/src/ingestion/ingestion-worker.ts
+++ b/src/ingestion/ingestion-worker.ts
@@ -3,7 +3,6 @@ import { prisma } from '../lib/prisma.js';
 import { readJournalData } from './reader/postgres-reader.js';
 import { buildJournalDocuments } from './documents/document-builder.js';
 import { embedAndStoreDocument } from './embed-and-store.js';
-import { disconnectVectorStorage } from '../embeddings/vector-storage.js';
 import type { JournalDocument } from './documents/document-types.js';
 
 export interface IngestionFailure {
@@ -110,9 +109,6 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       process.exitCode = 1;
     })
     .finally(async () => {
-      // embedAndStoreDocument (via vector-storage.ts) uses its own separate
-      // PrismaClient instance -- disconnect it too, or its connection pool
-      // can keep the process alive after this reports completion.
-      await Promise.all([prisma.$disconnect(), disconnectVectorStorage()]);
+      await prisma.$disconnect();
     });
 }

--- a/src/rag/citation-source-mapper.ts
+++ b/src/rag/citation-source-mapper.ts
@@ -1,7 +1,5 @@
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '../lib/prisma.js';
 import type { Citation } from './citation-builder.js';
-
-const prisma = new PrismaClient();
 
 export async function mapCitationSources(
   citations: Array<Pick<Citation, 'sourceType' | 'sourceId'>>,

--- a/src/rag/citation-verifier.ts
+++ b/src/rag/citation-verifier.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { prisma } from '../lib/prisma.js';
 
 export async function verifyCitations(
   citations: Array<{

--- a/tests/citation-source-mapper.test.ts
+++ b/tests/citation-source-mapper.test.ts
@@ -9,8 +9,8 @@ const prismaMock = {
   },
 };
 
-jest.unstable_mockModule('@prisma/client', () => ({
-  PrismaClient: jest.fn().mockImplementation(() => prismaMock),
+jest.unstable_mockModule('../src/lib/prisma.js', () => ({
+  prisma: prismaMock,
 }));
 
 const { mapCitationSources } =

--- a/tests/citation-verifier.test.ts
+++ b/tests/citation-verifier.test.ts
@@ -2,15 +2,15 @@ import { jest } from '@jest/globals';
 
 const findFirstMock = jest.fn();
 
-jest.unstable_mockModule('@prisma/client', () => ({
-  PrismaClient: jest.fn().mockImplementation(() => ({
+jest.unstable_mockModule('../src/lib/prisma.js', () => ({
+  prisma: {
     treatment: {
       findFirst: findFirstMock,
     },
     medicalVisit: {
       findFirst: findFirstMock,
     },
-  })),
+  },
 }));
 
 const { verifyCitations } = await import('../src/rag/citation-verifier.js');

--- a/tests/vector-storage.test.ts
+++ b/tests/vector-storage.test.ts
@@ -30,15 +30,18 @@ const joinMock = jest.fn((values: unknown[], separator?: string) => ({
 const emptyMarker = { __empty__: true };
 
 jest.unstable_mockModule('@prisma/client', () => ({
-  PrismaClient: jest.fn().mockImplementation(() => ({
-    $executeRaw: executeRawMock,
-    $queryRaw: queryRawMock,
-    $disconnect: disconnectMock,
-  })),
   Prisma: {
     sql: sqlMock,
     join: joinMock,
     empty: emptyMarker,
+  },
+}));
+
+jest.unstable_mockModule('../src/lib/prisma.js', () => ({
+  prisma: {
+    $executeRaw: executeRawMock,
+    $queryRaw: queryRawMock,
+    $disconnect: disconnectMock,
   },
 }));
 


### PR DESCRIPTION
## Summary
- `vector-storage.ts`, `journal-tool.ts`, `citation-source-mapper.ts`, and `citation-verifier.ts` each constructed their own `PrismaClient`; they now import the shared singleton from `src/lib/prisma.ts` instead.
- Updated the three unit tests that mocked `@prisma/client`'s `PrismaClient` constructor directly to instead mock `src/lib/prisma.ts`'s exported `prisma`, matching the new import target.
- Marked the item done in `docs/04-implementation-roadmap.md` and removed the duplicate leftover bullet.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (175/175 passed)

Fixes #47