### PR TITLE
chore: move stray test functions out of embedding_api.py into test_embedding_api_unit.py

### DIFF
--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -117,7 +117,9 @@ Infrastructure as Code) — both are cloud-infra concepts with no local-codebase
   covered in `tests/journal-tool.test.ts`. (#44)
 - [ ] Surface `AgentState.intent` in the actual HTTP response — it's computed, tracked, and then
   discarded; a frontend needs exactly this field to know which response shape it received. (#45)
-- [ ] Clean up the stray Python test functions embedded at module level in `embedding_api.py`. (#48)
+- [x] Clean up the stray Python test functions embedded at module level in `embedding_api.py` —
+  moved into `test_embedding_api_unit.py`'s existing `TestEmbedEndpoint`/`TestEmbedBatchEndpoint`
+  classes. (#48)
 
 **Frontend-readiness gaps — new "Step 10" candidate, sequenced after Step 5 (security), since
 building frontend-facing endpoints without auth would just mean redoing them:**

--- a/src/embeddings/embedding_api.py
+++ b/src/embeddings/embedding_api.py
@@ -55,23 +55,6 @@ def embed_query(request: EmbeddingRequest):
         "version": "qwen3-embedding-0.6b-v1",
     }
 
-def test_rejects_text_over_max_length(self, client, fake_service):
-    response = client.post(
-        "/embed",
-        json={"text": "x" * 10_001},
-    )
-
-    assert response.status_code == 422
-    assert fake_service.embed_document_calls == []
-
-def test_accepts_maximum_text_length(self, client, fake_service):
-    response = client.post(
-        "/embed",
-        json={"text": "x" * 10_000},
-    )
-
-    assert response.status_code == 200
-
 
 @app.post("/embed-batch")
 def embed_batch(request: BatchEmbeddingRequest):
@@ -90,20 +73,3 @@ def embed_batch(request: BatchEmbeddingRequest):
         "dimension": len(embeddings[0]),
         "version": "qwen3-embedding-0.6b-v1",
     }
-
-def test_rejects_batch_over_max_size(self, client, fake_service):
-    response = client.post(
-        "/embed-batch",
-        json={"texts": ["x"] * 33},
-    )
-
-    assert response.status_code == 422
-    assert fake_service.embed_batch_calls == []
-
-def test_accepts_maximum_batch_size(self, client, fake_service):
-    response = client.post(
-        "/embed-batch",
-        json={"texts": ["x"] * 32},
-    )
-
-    assert response.status_code == 200

--- a/src/embeddings/test_embedding_api_unit.py
+++ b/src/embeddings/test_embedding_api_unit.py
@@ -161,6 +161,23 @@ class TestEmbedEndpoint:
         assert response.status_code == 200
         assert fake_service.embed_document_calls == ["hello"]
 
+    def test_rejects_text_over_max_length(self, client, fake_service):
+        response = client.post(
+            "/embed",
+            json={"text": "x" * 10_001},
+        )
+
+        assert response.status_code == 422
+        assert fake_service.embed_document_calls == []
+
+    def test_accepts_maximum_text_length(self, client, fake_service):
+        response = client.post(
+            "/embed",
+            json={"text": "x" * 10_000},
+        )
+
+        assert response.status_code == 200
+
 
 class TestEmbedQueryEndpoint:
     def test_returns_200_with_expected_payload_shape(self, client, fake_service):
@@ -239,3 +256,20 @@ class TestEmbedBatchEndpoint:
 
         assert response.json()["embeddings"] == [[1.0], [2.0], [3.0]]
         assert fake_service.embed_batch_calls == [["x", "y", "z"]]
+
+    def test_rejects_batch_over_max_size(self, client, fake_service):
+        response = client.post(
+            "/embed-batch",
+            json={"texts": ["x"] * 33},
+        )
+
+        assert response.status_code == 422
+        assert fake_service.embed_batch_calls == []
+
+    def test_accepts_maximum_batch_size(self, client, fake_service):
+        response = client.post(
+            "/embed-batch",
+            json={"texts": ["x"] * 32},
+        )
+
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Four `test_*` functions (`test_rejects_text_over_max_length`, `test_accepts_maximum_text_length`, `test_rejects_batch_over_max_size`, `test_accepts_maximum_batch_size`) were defined at module level inside `embedding_api.py` (the actual FastAPI app file) instead of its sibling test file.
- Confirmed they weren't duplicates: `test_embedding_api_unit.py`'s `TestEmbedEndpoint`/`TestEmbedBatchEndpoint` classes cover everything else about `/embed` and `/embed-batch` but not the `Field(max_length=...)` validation behavior — these four were the only coverage for that.
- Also confirmed `embedding_api.py` doesn't match pytest's default discovery pattern and there's no pytest step in CI, so these were dead code (never collected/run) before this move — this fix makes them real, runnable tests.
- Moved them into the existing test classes with bodies/signatures unchanged. Checked off #48 in `docs/04-implementation-roadmap.md`.

No behavior change to the FastAPI app itself.

## Test plan
- [x] `python -m pytest src/embeddings/test_embedding_api_unit.py -v` — 21/21 passing, including the 4 moved tests
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — 173/173 passing

Fixes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for rejecting text exceeding the 10,000-character limit.
  * Added coverage for accepting text at the maximum allowed length.
  * Added coverage for rejecting batches larger than 32 items.
  * Added coverage for accepting batches at the maximum allowed size.

* **Documentation**
  * Updated the implementation roadmap to mark the related testing work as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->