### PR TITLE
chore: add Python dependency manifest for the embedding service

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Security/production hardening, AI observability, AWS deployment, and Infrastruct
 
 - Node.js 22 (matches CI)
 - A PostgreSQL database with the `pgvector` extension available (CI uses the `pgvector/pgvector:pg16` image)
-- A Python environment able to run the embedding service (`src/embeddings/embedding_api.py`) — FastAPI, `sentence-transformers`, and an ASGI server such as `uvicorn`. No dependency manifest for this service is currently committed to the repo.
+- A Python environment able to run the embedding service (`src/embeddings/embedding_api.py`) — dependencies are pinned in `src/embeddings/requirements.txt`.
 
 ### Install
 
@@ -75,9 +75,11 @@ Seeding uses two separate scripts, both with hard safety checks against running 
 
 ### Run the embedding service
 
-Start `src/embeddings/embedding_api.py` (a FastAPI app exposing `/embed` and `/embed-batch`) on whatever host/port `EMBEDDING_API_URL` points at, e.g.:
+Install the Python dependencies, then start `src/embeddings/embedding_api.py` (a FastAPI app
+exposing `/embed` and `/embed-batch`) on whatever host/port `EMBEDDING_API_URL` points at, e.g.:
 
 ```bash
+pip install -r src/embeddings/requirements.txt
 uvicorn src.embeddings.embedding_api:app --port 8000
 ```
 

--- a/src/embeddings/requirements.txt
+++ b/src/embeddings/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.141.1
+pydantic==2.13.4
+sentence-transformers==6.0.0
+uvicorn==0.52.3
+
+# test dependencies
+pytest==8.2.2
+httpx==0.28.1


### PR DESCRIPTION
## Summary
- Adds `src/embeddings/requirements.txt`, pinning the embedding service's runtime deps (`fastapi`, `pydantic`, `sentence-transformers`, `uvicorn`) and test deps (`pytest`, `httpx`) to versions verified working locally
- Updates `README.md` setup instructions to reference the manifest instead of disclosing the missing-manifest gap, and adds a `pip install` step to "Run the embedding service"

## Test plan
- [x] `pip install -r src/embeddings/requirements.txt --dry-run` resolves cleanly, no conflicts
- [x] `python -m pytest src/embeddings/` — 39/39 pass
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — 173/173 pass

Fixes #56