### PR TITLE
feat: add per-IP rate limiting to POST /ai-agent

### DIFF
--- a/docs/05-api-contract.md
+++ b/docs/05-api-contract.md
@@ -71,6 +71,7 @@ refusal response. Tracked as issue #86.
 |--------|------|---------|
 | 400 | `{ "error": "Question is required" }` | body present but `question` missing/blank |
 | 400 | `{ "error": "Invalid injuryId" }` | `injuryId` present but fails the check above |
+| 429 | `express-rate-limit` default JSON body | more than 20 requests from the same IP within a 60s window (issue #89) |
 | 500 | `{ "error": "Failed to process request" }` | catch-all — embedding service down, DB error, LLM call failure/invalid key. All collapse to this one message; no error code/type distinguishes the cause. |
 
 `askAgent` destructures `req.body ?? {}`, so a body-less `POST /ai-agent` returns the 400 above

--- a/docs/05-api-contract.md
+++ b/docs/05-api-contract.md
@@ -71,7 +71,7 @@ refusal response. Tracked as issue #86.
 |--------|------|---------|
 | 400 | `{ "error": "Question is required" }` | body present but `question` missing/blank |
 | 400 | `{ "error": "Invalid injuryId" }` | `injuryId` present but fails the check above |
-| 429 | `express-rate-limit` default JSON body | more than 20 requests from the same IP within a 60s window (issue #89) |
+| 429 | `{ "error": "Too many requests, please try again later." }` | more than 20 requests from the same IP within a 60s window (issue #89) |
 | 500 | `{ "error": "Failed to process request" }` | catch-all — embedding service down, DB error, LLM call failure/invalid key. All collapse to this one message; no error code/type distinguishes the cause. |
 
 `askAgent` destructures `req.body ?? {}`, so a body-less `POST /ai-agent` returns the 400 above

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bcrypt": "^6.0.0",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.6.2",
         "groq-sdk": "^1.5.0",
         "js-tiktoken": "^1.0.21"
       },
@@ -4255,6 +4256,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
@@ -4913,6 +4933,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "bcrypt": "^6.0.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.6.2",
     "groq-sdk": "^1.5.0",
     "js-tiktoken": "^1.0.21"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,8 @@ import aiAgentRouter from './routes/ai-agent-router.js';
 
 const app = express();
 
+app.set('trust proxy', 1);
+
 app.use(express.json());
 
 const aiAgentLimiter = rateLimit({
@@ -11,6 +13,7 @@ const aiAgentLimiter = rateLimit({
   limit: 20,
   standardHeaders: true,
   legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later.' },
 });
 
 app.use('/ai-agent', aiAgentLimiter, aiAgentRouter);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,18 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import aiAgentRouter from './routes/ai-agent-router.js';
 
 const app = express();
 
 app.use(express.json());
 
-app.use('/ai-agent', aiAgentRouter);
+const aiAgentLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+app.use('/ai-agent', aiAgentLimiter, aiAgentRouter);
 
 export default app;

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -7,20 +7,36 @@ import request from 'supertest';
  * this test fast and dependency-free while still exercising the real
  * rate-limit middleware mounted on `/ai-agent` in src/app.ts.
  *
+ * llm-client.js is mocked before each import: it constructs a real Groq
+ * client at module load time (requires GROQ_API_KEY), which the safety
+ * path never actually needs — mocking avoids depending on that env var
+ * being set at all just to import src/app.js.
+ *
  * Each test gets its own fresh app/prisma module instance (via
  * jest.resetModules()) so the in-memory rate-limit counter from one test
  * doesn't bleed into another.
  */
 const SAFETY_BLOCKED_QUESTION = 'Do I have a fracture?';
 
+async function loadApp() {
+  jest.resetModules();
+
+  jest.unstable_mockModule('../src/llm/llm-client.js', () => ({
+    generateAnswer: jest.fn(),
+  }));
+
+  const { default: app } = await import('../src/app.js');
+  const { prisma } = await import('../src/lib/prisma.js');
+
+  return { app, prisma };
+}
+
 describe('POST /ai-agent rate limiting', () => {
   it('does not crash when a reverse proxy sends X-Forwarded-For', async () => {
     // Regression test: express-rate-limit throws if a proxy header is
     // present but Express's 'trust proxy' setting isn't configured — this
     // would otherwise 500 every request once deployed behind a proxy/LB.
-    jest.resetModules();
-    const { default: app } = await import('../src/app.js');
-    const { prisma } = await import('../src/lib/prisma.js');
+    const { app, prisma } = await loadApp();
 
     try {
       const response = await request(app)
@@ -35,9 +51,7 @@ describe('POST /ai-agent rate limiting', () => {
   });
 
   it('allows up to the configured limit, then returns 429 with a JSON error body', async () => {
-    jest.resetModules();
-    const { default: app } = await import('../src/app.js');
-    const { prisma } = await import('../src/lib/prisma.js');
+    const { app, prisma } = await loadApp();
 
     try {
       for (let i = 0; i < 20; i++) {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,0 +1,66 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+/**
+ * Uses a safety-blocked question so the request never reaches the DB,
+ * embedding service, or LLM (safetyTool runs before any of that), keeping
+ * this test fast and dependency-free while still exercising the real
+ * rate-limit middleware mounted on `/ai-agent` in src/app.ts.
+ *
+ * Each test gets its own fresh app/prisma module instance (via
+ * jest.resetModules()) so the in-memory rate-limit counter from one test
+ * doesn't bleed into another.
+ */
+const SAFETY_BLOCKED_QUESTION = 'Do I have a fracture?';
+
+describe('POST /ai-agent rate limiting', () => {
+  it('does not crash when a reverse proxy sends X-Forwarded-For', async () => {
+    // Regression test: express-rate-limit throws if a proxy header is
+    // present but Express's 'trust proxy' setting isn't configured — this
+    // would otherwise 500 every request once deployed behind a proxy/LB.
+    jest.resetModules();
+    const { default: app } = await import('../src/app.js');
+    const { prisma } = await import('../src/lib/prisma.js');
+
+    try {
+      const response = await request(app)
+        .post('/ai-agent')
+        .set('X-Forwarded-For', '203.0.113.5')
+        .send({ question: SAFETY_BLOCKED_QUESTION });
+
+      expect(response.status).toBe(200);
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  it('allows up to the configured limit, then returns 429 with a JSON error body', async () => {
+    jest.resetModules();
+    const { default: app } = await import('../src/app.js');
+    const { prisma } = await import('../src/lib/prisma.js');
+
+    try {
+      for (let i = 0; i < 20; i++) {
+        const response = await request(app)
+          .post('/ai-agent')
+          .send({ question: SAFETY_BLOCKED_QUESTION });
+
+        expect(response.status).toBe(200);
+      }
+
+      const limitedResponse = await request(app)
+        .post('/ai-agent')
+        .send({ question: SAFETY_BLOCKED_QUESTION });
+
+      expect(limitedResponse.status).toBe(429);
+      expect(limitedResponse.headers['content-type']).toMatch(
+        /application\/json/,
+      );
+      expect(limitedResponse.body).toEqual({
+        error: 'Too many requests, please try again later.',
+      });
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `express-rate-limit` scoped to `POST /ai-agent` (20 requests/IP/60s) to stop unbounded LLM/embedding cost-abuse — every request that passes basic validation triggers a paid Groq call and an embedding-service call, with no auth (#46) and no rate limiting anywhere today.
- `app.set('trust proxy', 1)` — without this, `express-rate-limit` throws (and 500s every request) as soon as it's deployed behind any reverse proxy/load balancer sending `X-Forwarded-For`. Caught in self-review.
- 429 responses now return `{ "error": "..." }` (matching this endpoint's existing error-JSON contract) instead of `express-rate-limit`'s default plain-text body.
- Documents the new `429` response in `docs/05-api-contract.md`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (175/175, includes new `tests/app.test.ts` covering the 429 limit itself and the trust-proxy regression)
- [x] `npm run test:integration` (18/18, including `ai-agent-route.integration.test.ts` which makes 6 sequential requests/run — confirms the limiter doesn't interfere with normal use)

Fixes #89