### PR TITLE
feat: validate ai-agent request body with Zod, add max question length

### DIFF
--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -73,7 +73,10 @@ issues — a security gap-analysis pass also surfaced items #31's own text never
 *Urgent (no dependencies, do first):*
 - [ ] Add rate limiting to prevent LLM/embedding cost-abuse and resource exhaustion — confirmed
   exploitable today (no auth, no rate limit, every request triggers a paid Groq + embedding call). (#89)
-- [ ] Add schema-based request input validation (Zod) incl. a max question length. (#90)
+- [x] Add schema-based request input validation (Zod) incl. a max question length —
+  `ai-agent-controller.ts` now validates `question`/`injuryId` via a Zod schema instead of ad hoc
+  inline checks, and `question` has a real 10,000-character upper bound (matching the embedding
+  service's own `EmbeddingRequest.text` limit). (#90)
 - [ ] Regression tests for data isolation boundaries — currently zero tests exist proving
   cross-user chunk leakage can't happen when `injuryId` is omitted (requested explicitly in #31's
   own text). (#91)

--- a/docs/05-api-contract.md
+++ b/docs/05-api-contract.md
@@ -38,7 +38,7 @@ record. This is a known, unaddressed gap (see CLAUDE.md §9 on user-level data i
 
 | Field       | Type     | Required | Validation |
 |-------------|----------|----------|------------|
-| `question`  | `string` | yes      | non-empty after trim |
+| `question`  | `string` | yes      | non-empty after trim, max 10,000 characters |
 | `injuryId`  | `number` | no       | `Number.isSafeInteger`, `> 0`, **and** `<= 2147483647` |
 
 **Response — 200, shape depends on which internal path ran. An `intent` field

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "groq-sdk": "^1.5.0",
-        "js-tiktoken": "^1.0.21"
+        "js-tiktoken": "^1.0.21",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -7953,6 +7954,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "groq-sdk": "^1.5.0",
-    "js-tiktoken": "^1.0.21"
+    "js-tiktoken": "^1.0.21",
+    "zod": "^4.4.3"
   }
 }

--- a/src/ai-agent/ai-agent-controller.ts
+++ b/src/ai-agent/ai-agent-controller.ts
@@ -1,6 +1,19 @@
 import { randomUUID } from 'node:crypto';
 import { Request, Response } from 'express';
+import { z } from 'zod';
 import { runAgent } from './ai-agent-orchestrator.js';
+
+// Mirrors EmbeddingRequest.text's own Field(max_length=10_000) in
+// src/embeddings/embedding_api.py -- the question is what gets embedded.
+const MAX_QUESTION_LENGTH = 10_000;
+
+const askAgentSchema = z.object({
+  question: z
+    .string()
+    .max(MAX_QUESTION_LENGTH)
+    .refine((value) => value.trim().length > 0),
+  injuryId: z.number().int().positive().max(2_147_483_647).optional(),
+});
 
 export async function askAgent(req: Request, res: Response) {
   try {
@@ -10,24 +23,44 @@ export async function askAgent(req: Request, res: Response) {
         ? headerRequestId
         : randomUUID();
 
-    const { question, injuryId } = req.body ?? {};
+    const parsed = askAgentSchema.safeParse(req.body ?? {});
 
-    if (typeof question !== 'string' || question.trim().length === 0) {
+    if (!parsed.success) {
+      const questionIssue = parsed.error.issues.find(
+        (issue) => issue.path[0] === 'question',
+      );
+
+      if (questionIssue) {
+        if (questionIssue.code === 'too_big') {
+          return res.status(400).json({
+            error: `Question exceeds maximum length of ${MAX_QUESTION_LENGTH} characters`,
+          });
+        }
+
+        return res.status(400).json({
+          error: 'Question is required',
+        });
+      }
+
+      const injuryIdIssue = parsed.error.issues.find(
+        (issue) => issue.path[0] === 'injuryId',
+      );
+
+      if (injuryIdIssue) {
+        return res.status(400).json({
+          error: 'Invalid injuryId',
+        });
+      }
+
+      // Root-level type mismatch (e.g. a non-object JSON body like a bare
+      // string or array) -- neither field can be resolved, so report the
+      // same "missing question" error the old ad hoc checks gave for this case.
       return res.status(400).json({
         error: 'Question is required',
       });
     }
 
-    if (
-      injuryId !== undefined &&
-      (!Number.isSafeInteger(injuryId) ||
-        injuryId <= 0 ||
-        injuryId > 2_147_483_647)
-    ) {
-      return res.status(400).json({
-        error: 'Invalid injuryId',
-      });
-    }
+    const { question, injuryId } = parsed.data;
 
     const result = await runAgent(question, injuryId, requestId);
 

--- a/tests/ai-agent-controller.test.ts
+++ b/tests/ai-agent-controller.test.ts
@@ -177,6 +177,60 @@ describe('ai agent controller', () => {
     expect(runAgentMock).not.toHaveBeenCalled();
   });
 
+  it('returns 400 when question exceeds the maximum length', async () => {
+    const req: MockRequest = {
+      body: {
+        question: 'x'.repeat(10_001),
+      },
+    };
+
+    const res = mockResponse();
+
+    await askAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Question exceeds maximum length of 10000 characters',
+    });
+
+    expect(runAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a question at exactly the maximum length', async () => {
+    const req: MockRequest = {
+      body: {
+        question: 'x'.repeat(10_000),
+      },
+    };
+
+    const res = mockResponse();
+
+    runAgentMock.mockResolvedValue({
+      answer: 'ok',
+      citations: [],
+    });
+
+    await askAgent(req, res);
+
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(runAgentMock).toHaveBeenCalled();
+  });
+
+  it('returns "Question is required" when the body is a non-object JSON value', async () => {
+    const req = { body: 'not an object' } as unknown as MockRequest;
+
+    const res = mockResponse();
+
+    await askAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Question is required',
+    });
+
+    expect(runAgentMock).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when injuryId is not a number', async () => {
     const req: MockRequest = {
       body: {


### PR DESCRIPTION
## Summary
- Replaces ad hoc inline validation in `ai-agent-controller.ts` with a Zod schema for `question`/`injuryId`.
- Adds a real 10,000-character max length on `question`, matching the embedding service's own `EmbeddingRequest.text` limit — closes an unbounded-payload cost/latency abuse surface.
- Preserves the existing error-response contract exactly (`'Question is required'`, `'Invalid injuryId'`) including for a malformed non-object JSON body edge case.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (37/37 suites, 176/176 tests)
- [x] Added tests: over-max-length rejection, exact-boundary acceptance, non-object body edge case

Fixes #90