### PR TITLE
fix: redact raw error objects in console.error catch blocks

### DIFF
--- a/src/ai-agent/ai-agent-controller.ts
+++ b/src/ai-agent/ai-agent-controller.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { Request, Response } from 'express';
 import { runAgent } from './ai-agent-orchestrator.js';
+import { logError } from '../lib/log-error.js';
 
 export async function askAgent(req: Request, res: Response) {
   try {
@@ -33,7 +34,7 @@ export async function askAgent(req: Request, res: Response) {
 
     return res.json(result);
   } catch (error) {
-    console.error(error);
+    logError('ai-agent request failed', error);
 
     return res.status(500).json({
       error: 'Failed to process request',

--- a/src/ingestion/ingestion-worker.ts
+++ b/src/ingestion/ingestion-worker.ts
@@ -3,6 +3,7 @@ import { prisma } from '../lib/prisma.js';
 import { readJournalData } from './reader/postgres-reader.js';
 import { buildJournalDocuments } from './documents/document-builder.js';
 import { embedAndStoreDocument } from './embed-and-store.js';
+import { logError } from '../lib/log-error.js';
 import type { JournalDocument } from './documents/document-types.js';
 
 export interface IngestionFailure {
@@ -46,7 +47,7 @@ export async function runIngestion(): Promise<IngestionResult> {
   try {
     documents = buildJournalDocuments(injuries);
   } catch (error) {
-    console.error('Failed to build journal documents for this ingestion run:', error);
+    logError('Failed to build journal documents for this ingestion run', error);
     return {
       total: 1,
       succeeded: 0,
@@ -65,9 +66,9 @@ export async function runIngestion(): Promise<IngestionResult> {
       await embedAndStoreDocument(document);
       result.succeeded += 1;
     } catch (error) {
-      console.error(
+      logError(
         `Ingestion failed for sourceType=${document.metadata.sourceType} ` +
-          `sourceId=${document.metadata.sourceId} injuryId=${document.metadata.injuryId}:`,
+          `sourceId=${document.metadata.sourceId} injuryId=${document.metadata.injuryId}`,
         error,
       );
       result.failed.push({
@@ -105,7 +106,7 @@ async function main() {
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main()
     .catch((error) => {
-      console.error(error);
+      logError('Ingestion run failed', error);
       process.exitCode = 1;
     })
     .finally(async () => {

--- a/src/lib/log-error.ts
+++ b/src/lib/log-error.ts
@@ -1,0 +1,18 @@
+function toMinimalRepresentation(error: unknown): { name: string; message: string } {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+
+  return { name: 'UnknownError', message: String(error) };
+}
+
+/**
+ * Logs an error without exposing its raw object or stack trace, which can
+ * carry file paths, connection strings, or request payloads depending on
+ * what threw.
+ */
+export function logError(context: string, error: unknown): void {
+  const { name, message } = toMinimalRepresentation(error);
+
+  console.error(`${context}: ${name}: ${message}`);
+}

--- a/tests/log-error.test.ts
+++ b/tests/log-error.test.ts
@@ -1,0 +1,65 @@
+import { jest } from '@jest/globals';
+import { logError } from '../src/lib/log-error.js';
+
+describe('logError', () => {
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('logs the error name and message for an Error instance', () => {
+    const error = new Error('connection refused');
+
+    logError('db query failed', error);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'db query failed: Error: connection refused',
+    );
+  });
+
+  it('logs a custom Error subclass name', () => {
+    class TimeoutError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'TimeoutError';
+      }
+    }
+
+    logError('embedding request failed', new TimeoutError('took too long'));
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'embedding request failed: TimeoutError: took too long',
+    );
+  });
+
+  it('never includes the stack trace in the logged output', () => {
+    const error = new Error('leaky');
+
+    logError('context', error);
+
+    const loggedArgs = consoleErrorSpy.mock.calls[0];
+
+    expect(loggedArgs.join(' ')).not.toContain(error.stack);
+  });
+
+  it('handles a non-Error thrown value', () => {
+    logError('unexpected throw', 'just a string');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'unexpected throw: UnknownError: just a string',
+    );
+  });
+
+  it('handles a thrown object with no message', () => {
+    logError('unexpected throw', { code: 'ECONNRESET' });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'unexpected throw: UnknownError: [object Object]',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `logError(context, error)` helper (`src/lib/log-error.ts`) that logs only the error name and message, never the raw object or stack trace.
- Route the 4 existing `console.error(error)` catch-block call sites (`ai-agent-controller.ts`, 3x `ingestion-worker.ts`) through it, since a raw `Error` can carry file paths, connection strings, or request payloads depending on what threw.

Fixes #92

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (178/178 passing, including new `tests/log-error.test.ts`)