### PR TITLE
feat: add output-side safety check for LLM-generated answers

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -286,11 +286,21 @@ flowchart TD
 
     S -->|Allowed| C["Continue"]
     S -->|Boundary Violation| R["Refuse / Redirect"]
+
+    C --> G["Generate Answer"]
+    G --> O["Output Safety Check"]
+    O -->|Allowed| A["Return Answer"]
+    O -->|Diagnosis-like| R
 ```
 
-> **Current status:** this covers the input side only. There is no output-side check — nothing
-> verifies the LLM's generated answer against diagnosis-adjacent language it might echo from raw
-> journal content (e.g. a doctor's note). Output safety checks are future work.
+> **Current status:** both sides are covered. `checkSafety` (`src/safety/safety-service.ts`)
+> inspects the raw question before retrieval; `checkAnswerSafety` in the same file inspects the
+> LLM's generated answer afterward (in `rag-service.ts` and the journal-intent branch of
+> `ai-agent-orchestrator.ts`) and withholds it if the LLM hedges toward its own diagnostic
+> judgment ("you may have...", "this could be..."). It deliberately does not flag a definite
+> restatement of a diagnosis already present in the record (e.g. quoting a doctor's note) — that
+> grounded restatement is the app's core journal-summary behavior, not a leak; only the assistant
+> appearing to infer a *new* diagnosis on its own is treated as unsafe output.
 
 ### 5.5. AI Agent Architecture
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -194,13 +194,16 @@ flowchart TD
     DB --> DATA
 
     DATA --> G["LLM"]
-    G --> CV["Citation Generation"]
+    G --> OSC["Output Safety Check"]
+    OSC -->|Allowed| CV["Citation Generation"]
+    OSC -->|Diagnosis-like| REF
     CV --> OUT["Answer + Sources"]
 
     OUT --> U
 ```
 
-> Same caveat as §3: `AUTH` ("Per-Tool Authorization") is not implemented. See §5.5.
+> Same caveat as §3: `AUTH` ("Per-Tool Authorization") is not implemented. See §5.5. `OSC`
+> ("Output Safety Check") is `checkAnswerSafety` — see §5.4 for what it actually checks.
 
 ### 5.1. Semantic Retrieval Architecture
 
@@ -293,14 +296,17 @@ flowchart TD
     O -->|Diagnosis-like| R
 ```
 
-> **Current status:** both sides are covered. `checkSafety` (`src/safety/safety-service.ts`)
-> inspects the raw question before retrieval; `checkAnswerSafety` in the same file inspects the
-> LLM's generated answer afterward (in `rag-service.ts` and the journal-intent branch of
-> `ai-agent-orchestrator.ts`) and withholds it if the LLM hedges toward its own diagnostic
-> judgment ("you may have...", "this could be..."). It deliberately does not flag a definite
-> restatement of a diagnosis already present in the record (e.g. quoting a doctor's note) — that
-> grounded restatement is the app's core journal-summary behavior, not a leak; only the assistant
-> appearing to infer a *new* diagnosis on its own is treated as unsafe output.
+> **Current status:** both sides are covered, but only as pattern-based text filtering.
+> `checkSafety` (`src/safety/safety-service.ts`) inspects the raw question before retrieval;
+> `checkAnswerSafety` in the same file inspects the LLM's generated answer afterward (in
+> `rag-service.ts` and the journal-intent branch of `ai-agent-orchestrator.ts`) and withholds it
+> if the LLM hedges toward its own diagnostic judgment ("you may have...", "this could be...").
+> `checkAnswerSafety` receives only the answer text and `requestId` — it has no access to the
+> journal record or retrieved chunks, so it cannot distinguish a definite diagnostic statement
+> that's grounded in the record from one the LLM invented. It allows **all** definite diagnostic
+> statements through unconditionally ("you have X", "diagnosis: X"), whether or not they're
+> actually supported by the journal data. Verifying definite assertions against source evidence
+> is tracked separately (issue #142).
 
 ### 5.5. AI Agent Architecture
 

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -91,8 +91,10 @@ issues — a security gap-analysis pass also surfaced items #31's own text never
   on #94. (#95)
 - [x] Output-side safety check — `checkAnswerSafety` (`src/safety/safety-service.ts`) withholds
   an LLM answer that hedges toward its own diagnostic judgment ("you may have...", "this could
-  be..."), while still allowing a definite restatement of a diagnosis already in the record.
-  Wired into both `rag-service.ts` and the journal-intent path in `ai-agent-orchestrator.ts`. (#96)
+  be..."). It's pattern-based text filtering only — it has no access to the journal record, so it
+  allows all definite diagnostic statements through unconditionally, grounded or not. Verifying
+  definite assertions against source evidence is separate follow-up work (#142). Wired into both
+  `rag-service.ts` and the journal-intent path in `ai-agent-orchestrator.ts`. (#96)
 
 *Optional (safe to defer indefinitely):*
 - [ ] Add helmet + CORS security headers — low value until a real deployed origin/frontend exists. (#97)

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -21,7 +21,7 @@ truth for status; the issues are. Re-sync this file whenever a linked issue's st
   - [x] 2.3 Semantic Retrieval (#25)
   - [x] 2.4 Basic RAG (#26)
   - [x] 2.5 Citations *(generation only — verification not wired in, see below)* (#27)
-  - [x] 2.6 Safety Guardrails *(input-side only — no output-side check)* (#28)
+  - [x] 2.6 Safety Guardrails *(input- and output-side)* (#28, #96)
   - [x] 2.7 AI Agent *(keyword routing, not per-tool authorization)* (#29)
 - [x] Step 3 — Evaluation *(harness exists; two of four dimensions are shallow, one is unimplemented)* (#30)
 - [x] Step 4 — Integration Tests (#17)
@@ -89,8 +89,10 @@ issues — a security gap-analysis pass also surfaced items #31's own text never
   (does this backend own auth, or verify tokens from a separate app?). (#94)
 - [ ] Per-tool + retrieval/vector-level authorization enforcing user-level data isolation — depends
   on #94. (#95)
-- [ ] Output-side safety check — the current safety layer is entirely pre-generation; nothing
-  checks whether the LLM's answer echoes diagnosis-adjacent language from a chunk's raw content. (#96)
+- [x] Output-side safety check — `checkAnswerSafety` (`src/safety/safety-service.ts`) withholds
+  an LLM answer that hedges toward its own diagnostic judgment ("you may have...", "this could
+  be..."), while still allowing a definite restatement of a diagnosis already in the record.
+  Wired into both `rag-service.ts` and the journal-intent path in `ai-agent-orchestrator.ts`. (#96)
 
 *Optional (safe to defer indefinitely):*
 - [ ] Add helmet + CORS security headers — low value until a real deployed origin/frontend exists. (#97)

--- a/src/ai-agent/ai-agent-orchestrator.ts
+++ b/src/ai-agent/ai-agent-orchestrator.ts
@@ -5,6 +5,7 @@ import { routeIntent } from './ai-agent-intent-router.js';
 import { AgentState } from './ai-agent-state.js';
 import { buildPrompt } from '../rag/prompt-builder.js';
 import { generateAnswer } from '../llm/llm-client.js';
+import { checkAnswerSafety } from '../safety/safety-service.js';
 
 export async function runAgent(
   question: string,
@@ -64,6 +65,16 @@ export async function runAgent(
         return {
           answer:
             'Unable to generate a summary from your injury record right now.',
+          citations: [],
+          intent,
+        };
+      }
+
+      const answerSafety = checkAnswerSafety(answer, requestId);
+
+      if (!answerSafety.allowed) {
+        return {
+          answer: answerSafety.message,
           citations: [],
           intent,
         };

--- a/src/rag/rag-service.ts
+++ b/src/rag/rag-service.ts
@@ -3,7 +3,7 @@ import { buildContext } from './context-builder.js';
 import { buildPrompt } from './prompt-builder.js';
 import { generateAnswer } from '../llm/llm-client.js';
 import { buildCitations } from '../rag/citation-builder.js';
-import { checkSafety } from '../safety/safety-service.js';
+import { checkSafety, checkAnswerSafety } from '../safety/safety-service.js';
 
 export async function answerQuestion(
   question: string,
@@ -28,6 +28,16 @@ export async function answerQuestion(
   const prompt = buildPrompt(question, context, requestId);
 
   const answer = await generateAnswer(prompt, requestId);
+
+  const answerSafety = checkAnswerSafety(answer, requestId);
+
+  if (!answerSafety.allowed) {
+    return {
+      answer: answerSafety.message,
+      citations: [],
+      chunks: [],
+    };
+  }
 
   const citations = buildCitations(chunks, requestId);
 

--- a/src/safety/safety-service.ts
+++ b/src/safety/safety-service.ts
@@ -12,7 +12,7 @@ export type SafetyResult =
 // NOTE: this list will always be a step behind real-world phrasing (see review notes) —
 // treat this regex layer as a fast pre-filter, not the sole safety boundary. The downstream
 // LLM must also be instructed never to diagnose, regardless of how the question is phrased.
-const CONDITION_KEYWORDS =
+export const CONDITION_KEYWORDS =
   'injury|condition|disease|syndrome|disorder|diagnosis|tear|fracture|cancer|tumou?r|disc|herniation|infection|concussion|arthritis';
 
 const diagnosisPatterns = [
@@ -88,6 +88,53 @@ export function checkSafety(question: string, requestId?: string): SafetyResult 
       reason: 'diagnosis_request',
       message:
         'I cannot diagnose medical conditions, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
+    };
+  }
+
+  return {
+    allowed: true,
+  };
+}
+
+// Output-side counterpart to `diagnosisPatterns` above. Deliberately narrower than a
+// plain "does this contain a condition word" check: journal summaries routinely restate
+// a diagnosis that is already recorded (an injury's name, a doctor's note), and that
+// grounded restatement is the app's core function, not a leak. What this targets instead
+// is the LLM *hedging toward its own inference* -- speculative phrasing ("you may have",
+// "this could be") that reads as the assistant reaching a diagnostic judgment on its own,
+// rather than reporting a fact already present in the record. Definite statements
+// ("you have X", "diagnosis: X") are intentionally NOT flagged, since those are the
+// normal shape of a faithful summary of recorded data.
+const diagnosisLeakPatterns = [
+  new RegExp(
+    `you (?:may have|might have|could have|likely have|possibly have|appear to have)\\s+(?:a|an|any)?\\s*(?:\\w+\\s+){0,2}(?:${CONDITION_KEYWORDS})\\b`,
+    'i',
+  ),
+
+  new RegExp(
+    `this (?:could be|might be|may be|looks like|sounds like|appears to be)\\s+(?:a|an)?\\s*(?:\\w+\\s+){0,2}(?:${CONDITION_KEYWORDS})\\b`,
+    'i',
+  ),
+];
+
+export function checkAnswerSafety(
+  answer: string,
+  requestId?: string,
+): SafetyResult {
+  void requestId; // unused for now — reserved for future log correlation (#32)
+
+  const normalizedAnswer = answer.replace(/\s+/g, ' ').trim();
+
+  const isDiagnosisLeak = diagnosisLeakPatterns.some((pattern) =>
+    pattern.test(normalizedAnswer),
+  );
+
+  if (isDiagnosisLeak) {
+    return {
+      allowed: false,
+      reason: 'diagnosis_leak',
+      message:
+        'I withheld that response because it read like a medical diagnosis, which I cannot provide. I can summarize your recorded symptoms, tests, treatments, and medical history instead.',
     };
   }
 

--- a/tests/ai-agent-orchestrator.test.ts
+++ b/tests/ai-agent-orchestrator.test.ts
@@ -183,4 +183,62 @@ describe('agent orchestrator', () => {
       intent: 'journal',
     });
   });
+
+  it('withholds a journal answer where the assistant hedges toward its own diagnosis', async () => {
+    safetyToolMock.mockReturnValue({
+      allowed: true,
+    });
+
+    routeIntentMock.mockReturnValue('journal');
+
+    journalToolMock.mockResolvedValue({
+      id: 42,
+    });
+
+    formatInjuryRecordMock.mockReturnValue(
+      'Injury:\nSymptoms: knee pain and swelling after running.',
+    );
+
+    generateAnswerMock.mockResolvedValue(
+      'Based on these symptoms, you may have a meniscus tear.',
+    );
+
+    const result = await runAgent('Show my injury timeline', 42);
+
+    expect(result).toEqual({
+      answer:
+        'I withheld that response because it read like a medical diagnosis, which I cannot provide. I can summarize your recorded symptoms, tests, treatments, and medical history instead.',
+      citations: [],
+      intent: 'journal',
+    });
+  });
+
+  it('allows a journal answer that restates a diagnosis already in the record', async () => {
+    safetyToolMock.mockReturnValue({
+      allowed: true,
+    });
+
+    routeIntentMock.mockReturnValue('journal');
+
+    journalToolMock.mockResolvedValue({
+      id: 42,
+    });
+
+    formatInjuryRecordMock.mockReturnValue(
+      "Injury:\nNotes: Doctor's note: diagnosis of a meniscus tear.",
+    );
+
+    generateAnswerMock.mockResolvedValue(
+      'You have a meniscus tear, as noted in your medical visit on 2024-01-15.',
+    );
+
+    const result = await runAgent('Show my injury timeline', 42);
+
+    expect(result).toEqual({
+      answer:
+        'You have a meniscus tear, as noted in your medical visit on 2024-01-15.',
+      citations: [],
+      intent: 'journal',
+    });
+  });
 });

--- a/tests/rag-service.test.ts
+++ b/tests/rag-service.test.ts
@@ -6,6 +6,7 @@ const buildPromptMock = jest.fn();
 const generateAnswerMock = jest.fn();
 const buildCitationsMock = jest.fn();
 const checkSafetyMock = jest.fn();
+const checkAnswerSafetyMock = jest.fn();
 
 jest.unstable_mockModule('../src/rag/citation-builder.js', () => ({
   buildCitations: buildCitationsMock,
@@ -29,6 +30,7 @@ jest.unstable_mockModule('../src/llm/llm-client.js', () => ({
 
 jest.unstable_mockModule('../src/safety/safety-service.js', () => ({
   checkSafety: checkSafetyMock,
+  checkAnswerSafety: checkAnswerSafetyMock,
 }));
 
 const { answerQuestion } = await import('../src/rag/rag-service.js');
@@ -38,6 +40,10 @@ describe('rag service', () => {
     jest.clearAllMocks();
 
     checkSafetyMock.mockReturnValue({
+      allowed: true,
+    });
+
+    checkAnswerSafetyMock.mockReturnValue({
       allowed: true,
     });
   });
@@ -160,6 +166,45 @@ describe('rag service', () => {
 
     expect(semanticSearchMock).not.toHaveBeenCalled();
     expect(generateAnswerMock).not.toHaveBeenCalled();
+    expect(buildCitationsMock).not.toHaveBeenCalled();
+  });
+
+  it('withholds an answer that fails the output-side safety check', async () => {
+    const chunks = [
+      {
+        id: 1,
+        sourceType: 'treatment',
+        sourceId: 42,
+        content: "Doctor's note: diagnosis of torn meniscus.",
+      },
+    ];
+
+    semanticSearchMock.mockResolvedValue(chunks);
+    buildContextMock.mockReturnValue("Doctor's note: diagnosis of torn meniscus.");
+    buildPromptMock.mockReturnValue('prompt');
+    generateAnswerMock.mockResolvedValue(
+      'Based on these symptoms, you may have a torn meniscus.',
+    );
+
+    checkAnswerSafetyMock.mockReturnValue({
+      allowed: false,
+      reason: 'diagnosis_leak',
+      message: 'I withheld that response because it read like a medical diagnosis.',
+    });
+
+    const result = await answerQuestion('What did the doctor say?');
+
+    expect(checkAnswerSafetyMock).toHaveBeenCalledWith(
+      'Based on these symptoms, you may have a torn meniscus.',
+      undefined,
+    );
+
+    expect(result).toEqual({
+      answer: 'I withheld that response because it read like a medical diagnosis.',
+      citations: [],
+      chunks: [],
+    });
+
     expect(buildCitationsMock).not.toHaveBeenCalled();
   });
 

--- a/tests/safety-service.test.ts
+++ b/tests/safety-service.test.ts
@@ -1,4 +1,4 @@
-import { checkSafety } from '../src/safety/safety-service.js';
+import { checkSafety, checkAnswerSafety } from '../src/safety/safety-service.js';
 
 describe('safety service', () => {
   it('allows journal summary questions', () => {
@@ -183,5 +183,77 @@ describe('safety service', () => {
     questions.forEach((question) => {
       expect(checkSafety(question).allowed).toBe(false);
     });
+  });
+});
+
+describe('checkAnswerSafety', () => {
+  it('allows a normal summarizing answer', () => {
+    const result = checkAnswerSafety(
+      'You recorded physiotherapy on three occasions and noted improved mobility.',
+    );
+
+    expect(result).toEqual({
+      allowed: true,
+    });
+  });
+
+  it('blocks a hedged/inferential diagnosis via "you may have"', () => {
+    const result = checkAnswerSafety(
+      'Based on these symptoms, you may have a fracture.',
+    );
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'diagnosis_leak',
+      message:
+        'I withheld that response because it read like a medical diagnosis, which I cannot provide. I can summarize your recorded symptoms, tests, treatments, and medical history instead.',
+    });
+  });
+
+  it('blocks a hedged/inferential diagnosis via "this could be"', () => {
+    expect(
+      checkAnswerSafety('This could be a herniated disc.').allowed,
+    ).toBe(false);
+  });
+
+  it('blocks with extra whitespace/newlines in the answer', () => {
+    expect(
+      checkAnswerSafety('You    might have\n  arthritis.').allowed,
+    ).toBe(false);
+  });
+
+  it('allows an answer that references symptoms without affirming a diagnosis', () => {
+    const result = checkAnswerSafety(
+      'Your journal mentions knee pain and swelling after the run on March 3rd.',
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  // --- Regression coverage: grounded restatement of an already-recorded diagnosis
+  // is the app's core journal-summary behavior and must not be withheld. ---
+
+  it('allows a definite restatement of a diagnosis already in the record', () => {
+    const result = checkAnswerSafety(
+      'You have an ACL tear from a football injury, first recorded on 2024-01-15.',
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it('allows quoting a "Diagnosis:" label from a doctor\'s note', () => {
+    const result = checkAnswerSafety(
+      "Your medical visit on 2024-01-15 with Dr. Smith noted: Diagnosis: torn meniscus.",
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it('allows a definite "this is" restatement of a recorded condition', () => {
+    const result = checkAnswerSafety(
+      'This is the fracture you recorded on 2023-06-01, treated with a cast.',
+    );
+
+    expect(result.allowed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `checkAnswerSafety()` (`src/safety/safety-service.ts`) to inspect the LLM's *generated* answer, not just the input question — closing the gap called out in `docs/02-architecture.md` §5.4 where nothing verified whether the LLM echoed or inferred diagnosis-adjacent language.
- Wired into both `rag-service.ts` and the journal-intent branch of `ai-agent-orchestrator.ts`.
- Deliberately narrow: only withholds answers where the LLM hedges toward its own diagnostic judgment ("you may have...", "this could be..."). A definite restatement of a diagnosis already in the record (e.g. quoting a doctor's note) is still allowed, since that grounded restatement is the app's core journal-summary behavior, not a leak.
- Updated `docs/02-architecture.md` and `docs/04-implementation-roadmap.md` to reflect the closed gap.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (197/197 passing)
- [x] Added regression tests confirming hedged/inferential diagnostic language is blocked and grounded restatements of already-recorded diagnoses are allowed

Fixes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safety checks for AI-generated answers to detect unsupported diagnostic conclusions.
  - Unsafe responses are withheld and replaced with a safety message.
  - Grounded restatements of diagnoses already documented in the record remain available.

- **Bug Fixes**
  - Prevented diagnostic-sounding AI responses from being returned through journal and question-answering flows.

- **Tests**
  - Added coverage for blocked diagnostic inferences and allowed record-based restatements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->