### PR TITLE
feat: add helmet and CORS security headers to the Express app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ DATABASE_URL=
 LLM_API_KEY=
 EMBEDDING_API_KEY=
 JWT_SECRET=
+# Optional. Comma-separated list of allowed CORS origins. Leave unset until a
+# real frontend origin is deployed (see README).
+ALLOWED_ORIGIN=

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Set the following environment variables (see `.env.example` for a starting point
 | `EMBEDDING_API_URL` | No | Defaults to `http://127.0.0.1:8000` |
 | `EMBEDDING_API_TIMEOUT_MS` | No | Defaults to 30000 |
 | `PORT` | No | Defaults to 3000 |
+| `ALLOWED_ORIGIN` | No | Comma-separated list of allowed CORS origins. Unset reflects the request's own origin (no restriction) — low value until a real frontend is deployed at a known origin, at which point set this to lock CORS down. |
 
 ### Database
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
       "dependencies": {
         "@prisma/client": "^6.19.3",
         "bcrypt": "^6.0.0",
+        "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "express-rate-limit": "^8.6.2",
         "groq-sdk": "^1.5.0",
+        "helmet": "^8.3.0",
         "js-tiktoken": "^1.0.21",
         "jsonwebtoken": "^9.0.3",
         "zod": "^4.4.3"
@@ -22,6 +24,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/bcrypt": "^6.0.0",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
@@ -2006,6 +2009,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -3634,6 +3647,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-env": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
@@ -4857,6 +4887,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/html-escaper": {
@@ -6305,6 +6347,15 @@
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/bcrypt": "^6.0.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
@@ -54,10 +55,12 @@
   "dependencies": {
     "@prisma/client": "^6.19.3",
     "bcrypt": "^6.0.0",
+    "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "express-rate-limit": "^8.6.2",
     "groq-sdk": "^1.5.0",
+    "helmet": "^8.3.0",
     "js-tiktoken": "^1.0.21",
     "jsonwebtoken": "^9.0.3",
     "zod": "^4.4.3"

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,24 @@
 import express from 'express';
 import rateLimit from 'express-rate-limit';
+import helmet from 'helmet';
+import cors from 'cors';
 import aiAgentRouter from './routes/ai-agent-router.js';
 import { authenticate } from './auth/authenticate.js';
 
 const app = express();
 
 app.set('trust proxy', 1);
+
+app.use(helmet());
+
+// No real deployed frontend origin exists yet (see #97), so unset
+// ALLOWED_ORIGIN reflects the request's own origin -- identical to today's
+// behavior. Setting it restricts CORS to the given comma-separated origins.
+const allowedOrigins = process.env.ALLOWED_ORIGIN?.split(',').map((origin) =>
+  origin.trim(),
+);
+
+app.use(cors({ origin: allowedOrigins ?? true }));
 
 app.use(express.json());
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,12 +11,15 @@ app.set('trust proxy', 1);
 
 app.use(helmet());
 
-// No real deployed frontend origin exists yet (see #97), so unset
-// ALLOWED_ORIGIN reflects the request's own origin -- identical to today's
-// behavior. Setting it restricts CORS to the given comma-separated origins.
-const allowedOrigins = process.env.ALLOWED_ORIGIN?.split(',').map((origin) =>
-  origin.trim(),
-);
+// No real deployed frontend origin exists yet (see #97), so unset --
+// including present-but-blank, e.g. an unfilled ALLOWED_ORIGIN= copied from
+// .env.example -- reflects the request's own origin, identical to today's
+// behavior. Setting it to a non-empty value restricts CORS to the given
+// comma-separated origins.
+const rawAllowedOrigin = process.env.ALLOWED_ORIGIN?.trim();
+const allowedOrigins = rawAllowedOrigin
+  ? rawAllowedOrigin.split(',').map((origin) => origin.trim())
+  : undefined;
 
 app.use(cors({ origin: allowedOrigins ?? true }));
 

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -83,3 +83,77 @@ describe('POST /ai-agent rate limiting', () => {
     }
   });
 });
+
+describe('security headers and CORS', () => {
+  const originalAllowedOrigin = process.env.ALLOWED_ORIGIN;
+
+  afterEach(() => {
+    if (originalAllowedOrigin === undefined) {
+      delete process.env.ALLOWED_ORIGIN;
+    } else {
+      process.env.ALLOWED_ORIGIN = originalAllowedOrigin;
+    }
+  });
+
+  it('sets helmet security headers and removes X-Powered-By', async () => {
+    const { app, prisma } = await loadApp();
+
+    try {
+      const response = await request(app)
+        .post('/ai-agent')
+        .send({ question: SAFETY_BLOCKED_QUESTION });
+
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+      expect(response.headers['x-powered-by']).toBeUndefined();
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  it('reflects the request origin when ALLOWED_ORIGIN is unset', async () => {
+    delete process.env.ALLOWED_ORIGIN;
+
+    const { app, prisma } = await loadApp();
+
+    try {
+      const response = await request(app)
+        .post('/ai-agent')
+        .set('Origin', 'https://example.com')
+        .send({ question: SAFETY_BLOCKED_QUESTION });
+
+      expect(response.headers['access-control-allow-origin']).toBe(
+        'https://example.com',
+      );
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  it('restricts CORS to the configured origins when ALLOWED_ORIGIN is set', async () => {
+    process.env.ALLOWED_ORIGIN = 'https://allowed.example.com';
+
+    const { app, prisma } = await loadApp();
+
+    try {
+      const allowed = await request(app)
+        .post('/ai-agent')
+        .set('Origin', 'https://allowed.example.com')
+        .send({ question: SAFETY_BLOCKED_QUESTION });
+
+      expect(allowed.headers['access-control-allow-origin']).toBe(
+        'https://allowed.example.com',
+      );
+
+      const disallowed = await request(app)
+        .post('/ai-agent')
+        .set('Origin', 'https://not-allowed.example.com')
+        .send({ question: SAFETY_BLOCKED_QUESTION });
+
+      expect(
+        disallowed.headers['access-control-allow-origin'],
+      ).toBeUndefined();
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+});

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -129,6 +129,29 @@ describe('security headers and CORS', () => {
     }
   });
 
+  it('reflects the request origin when ALLOWED_ORIGIN is present but blank', async () => {
+    // Regression test: an unfilled `ALLOWED_ORIGIN=` copied verbatim from
+    // .env.example sets the env var to an empty string, not undefined --
+    // this must behave the same as fully unset, not silently block every
+    // cross-origin request.
+    process.env.ALLOWED_ORIGIN = '';
+
+    const { app, prisma } = await loadApp();
+
+    try {
+      const response = await request(app)
+        .post('/ai-agent')
+        .set('Origin', 'https://example.com')
+        .send({ question: SAFETY_BLOCKED_QUESTION });
+
+      expect(response.headers['access-control-allow-origin']).toBe(
+        'https://example.com',
+      );
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
   it('restricts CORS to the configured origins when ALLOWED_ORIGIN is set', async () => {
     process.env.ALLOWED_ORIGIN = 'https://allowed.example.com';
 


### PR DESCRIPTION
## Summary
- Mounts `helmet()` on the Express app for default security headers (CSP defaults, `X-Content-Type-Options`, removing `X-Powered-By`, etc.) — `src/app.ts` had no such middleware before.
- Mounts `cors()` configured from a new optional `ALLOWED_ORIGIN` env var: unset (today's default, no real frontend deployed) reflects the request's own origin (no behavior change); set to a comma-separated list, restricts CORS to those origins.
- Documented `ALLOWED_ORIGIN` in `README.md`'s env var table and `.env.example`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (189/189 passing)
- [x] Added tests asserting helmet headers are set and both CORS modes (unset → reflects origin, set → restricts to allowlist) behave correctly

Fixes #97