### PR TITLE
docs: document Groq data exposure and embedding-service auth gap as accepted risks

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -480,6 +480,17 @@ flowchart TD
     V --> D["User's Journal Data"]
 ```
 
+### 10.1 Accepted risks (not yet mitigated)
+
+- **Third-party LLM data exposure (Groq):** every RAG answer sends matched journal excerpts —
+  personal medical/injury data — to Groq's API (`src/llm/llm-client.ts`). No data-retention or
+  minimization control exists today; this is accepted as a tradeoff of using a third-party LLM
+  provider, not yet mitigated. Tracked as issue #117 (decide accept-as-is vs. minimization).
+- **Embedding service has no auth boundary:** `EMBEDDING_API_URL` (the Python/FastAPI service)
+  has no authentication. Acceptable only while strictly localhost-bound; must be revisited before
+  any deployment step (#33/#34) exposes it beyond localhost. Out of scope for #94/#95, which only
+  cover `/ai-agent`. Tracked as issue #118.
+
 ## 11. Architectural Decision Log
 
 For each major decision: what was chosen, why (as inferred from code, `CLAUDE.md`, and commit

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -95,8 +95,10 @@ issues — a security gap-analysis pass also surfaced items #31's own text never
 *Optional (safe to defer indefinitely):*
 - [ ] Add helmet + CORS security headers — low value until a real deployed origin/frontend exists. (#97)
 - [ ] Add `npm audit`/Dependabot/SCA scanning to CI. (#98)
-- [ ] Document third-party LLM data exposure (Groq) and the embedding service's missing auth
-  boundary as accepted risks. (#99)
+- [x] Document third-party LLM data exposure (Groq) and the embedding service's missing auth
+  boundary as accepted risks — see `docs/02-architecture.md` §10.1. Follow-up action items
+  filed as #117 (Groq data-retention decision) and #118 (embedding-service auth before
+  non-localhost deployment). (#99)
 
 *Deliberately not duplicated:* safe logging → already tracked under #32 ([P19] AI Observability);
 least-privilege IAM (AWS roles/policies) and secret rotation → already tracked under #34 ([P21]


### PR DESCRIPTION
## Summary
- Adds `docs/02-architecture.md` §10.1 naming two previously-undocumented risks: third-party LLM data exposure (Groq) and the embedding service's missing auth boundary.
- Files two follow-up issues so the future actions aren't just prose with no tracker entry: #117 (Groq data-retention/minimization decision) and #118 (embedding-service auth before non-localhost deployment).
- Marks #99 done in `docs/04-implementation-roadmap.md`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (40 suites / 186 tests passing)
- Docs-only change; no evaluation harness or integration tests required.

Fixes #99