### PR TITLE
feat: ground output-side diagnostic checks in retrieved/journal evidence

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -301,12 +301,14 @@ flowchart TD
 > `checkAnswerSafety` in the same file inspects the LLM's generated answer afterward (in
 > `rag-service.ts` and the journal-intent branch of `ai-agent-orchestrator.ts`) and withholds it
 > if the LLM hedges toward its own diagnostic judgment ("you may have...", "this could be...").
-> `checkAnswerSafety` receives only the answer text and `requestId` — it has no access to the
-> journal record or retrieved chunks, so it cannot distinguish a definite diagnostic statement
-> that's grounded in the record from one the LLM invented. It allows **all** definite diagnostic
-> statements through unconditionally ("you have X", "diagnosis: X"), whether or not they're
-> actually supported by the journal data. Verifying definite assertions against source evidence
-> is tracked separately (issue #142).
+> `checkAnswerSafety` also receives the retrieved chunks / journal record text as grounding
+> evidence, and blocks a definite diagnostic statement ("you have X", "diagnosis: X") whose
+> asserted term does not appear anywhere in that evidence (issue #142) — a definite restatement
+> of a diagnosis already in the record is still allowed, since that's the app's core
+> journal-summary behavior. This grounding check is still keyword-based: a diagnostic statement
+> using a specific medical term outside `CONDITION_KEYWORDS` (e.g. "meniscus", "ACL") is
+> invisible to it, same as every other pattern in this module (tracked separately as a
+> pre-existing coverage gap).
 
 ### 5.5. AI Agent Architecture
 

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -91,10 +91,13 @@ issues — a security gap-analysis pass also surfaced items #31's own text never
   on #94. (#95)
 - [x] Output-side safety check — `checkAnswerSafety` (`src/safety/safety-service.ts`) withholds
   an LLM answer that hedges toward its own diagnostic judgment ("you may have...", "this could
-  be..."). It's pattern-based text filtering only — it has no access to the journal record, so it
-  allows all definite diagnostic statements through unconditionally, grounded or not. Verifying
-  definite assertions against source evidence is separate follow-up work (#142). Wired into both
-  `rag-service.ts` and the journal-intent path in `ai-agent-orchestrator.ts`. (#96)
+  be..."). Wired into both `rag-service.ts` and the journal-intent path in
+  `ai-agent-orchestrator.ts`. (#96)
+- [x] Ground definite diagnostic assertions ("you have X", "diagnosis: X") against the
+  retrieved chunks / journal record passed into `checkAnswerSafety` as evidence, rather than
+  allowing them through unconditionally. Still keyword-based (`CONDITION_KEYWORDS`), so a
+  specific medical term outside that list is still invisible to the check — tracked separately
+  as a pre-existing coverage gap. (#142)
 
 *Optional (safe to defer indefinitely):*
 - [ ] Add helmet + CORS security headers — low value until a real deployed origin/frontend exists. (#97)

--- a/src/ai-agent/ai-agent-orchestrator.ts
+++ b/src/ai-agent/ai-agent-orchestrator.ts
@@ -70,7 +70,7 @@ export async function runAgent(
         };
       }
 
-      const answerSafety = checkAnswerSafety(answer, requestId);
+      const answerSafety = checkAnswerSafety(answer, context, requestId);
 
       if (!answerSafety.allowed) {
         return {

--- a/src/rag/rag-service.ts
+++ b/src/rag/rag-service.ts
@@ -29,7 +29,7 @@ export async function answerQuestion(
 
   const answer = await generateAnswer(prompt, requestId);
 
-  const answerSafety = checkAnswerSafety(answer, requestId);
+  const answerSafety = checkAnswerSafety(answer, context, requestId);
 
   if (!answerSafety.allowed) {
     return {

--- a/src/safety/safety-service.ts
+++ b/src/safety/safety-service.ts
@@ -117,13 +117,66 @@ const diagnosisLeakPatterns = [
   ),
 ];
 
+// Definite diagnostic assertions ("you have X", "diagnosis: X") are the normal shape of a
+// faithful summary of recorded data, so they're not flagged outright like the hedged patterns
+// above. Instead each one is checked against `evidence` (the retrieved chunks / journal record
+// text that was actually fed to the LLM) — a definite statement naming a condition that never
+// appears in that evidence is far more likely fabricated than grounded. Each pattern captures
+// the matched CONDITION_KEYWORDS term so it can be looked up in the evidence text.
+const definiteDiagnosisPatterns = [
+  new RegExp(
+    `you (?:have|had|have been diagnosed with|were diagnosed with)\\s+(?:a|an|any)?\\s*(?:\\w+\\s+){0,2}(${CONDITION_KEYWORDS})\\b`,
+    'gi',
+  ),
+
+  new RegExp(
+    `diagnos(?:is|ed with)(?:\\s+is)?:?\\s+(?:a|an|any)?\\s*(?:\\w+\\s+){0,2}(${CONDITION_KEYWORDS})\\b`,
+    'gi',
+  ),
+
+  new RegExp(
+    `this is (?:the|a|an)?\\s*(?:\\w+\\s+){0,2}(${CONDITION_KEYWORDS})\\b`,
+    'gi',
+  ),
+];
+
+// Finds the first definite-diagnosis term asserted in `answer` that does not appear anywhere
+// in `evidence`, or null if every asserted term is grounded (or none were asserted at all).
+function findUngroundedDiagnosisTerm(
+  answer: string,
+  evidence: string,
+): string | null {
+  for (const pattern of definiteDiagnosisPatterns) {
+    pattern.lastIndex = 0;
+
+    let match: RegExpExecArray | null;
+
+    while ((match = pattern.exec(answer)) !== null) {
+      const term = match[1];
+      const isGrounded = new RegExp(`\\b${term}\\b`, 'i').test(evidence);
+
+      if (!isGrounded) {
+        return term;
+      }
+
+      if (match.index === pattern.lastIndex) {
+        pattern.lastIndex += 1;
+      }
+    }
+  }
+
+  return null;
+}
+
 export function checkAnswerSafety(
   answer: string,
+  evidence = '',
   requestId?: string,
 ): SafetyResult {
   void requestId; // unused for now — reserved for future log correlation (#32)
 
   const normalizedAnswer = answer.replace(/\s+/g, ' ').trim();
+  const normalizedEvidence = evidence.replace(/\s+/g, ' ').trim();
 
   const isDiagnosisLeak = diagnosisLeakPatterns.some((pattern) =>
     pattern.test(normalizedAnswer),
@@ -135,6 +188,20 @@ export function checkAnswerSafety(
       reason: 'diagnosis_leak',
       message:
         'I withheld that response because it read like a medical diagnosis, which I cannot provide. I can summarize your recorded symptoms, tests, treatments, and medical history instead.',
+    };
+  }
+
+  const ungroundedTerm = findUngroundedDiagnosisTerm(
+    normalizedAnswer,
+    normalizedEvidence,
+  );
+
+  if (ungroundedTerm) {
+    return {
+      allowed: false,
+      reason: 'unsupported_diagnosis',
+      message:
+        'I withheld that response because it stated a diagnosis that is not supported by your recorded information. I can summarize what is actually documented in your journal instead.',
     };
   }
 

--- a/tests/ai-agent-orchestrator.test.ts
+++ b/tests/ai-agent-orchestrator.test.ts
@@ -241,4 +241,31 @@ describe('agent orchestrator', () => {
       intent: 'journal',
     });
   });
+
+  it('withholds a journal answer with a definite diagnosis not grounded in the record', async () => {
+    safetyToolMock.mockReturnValue({
+      allowed: true,
+    });
+
+    routeIntentMock.mockReturnValue('journal');
+
+    journalToolMock.mockResolvedValue({
+      id: 42,
+    });
+
+    formatInjuryRecordMock.mockReturnValue(
+      'Injury:\nSymptoms: knee pain and swelling after running.',
+    );
+
+    generateAnswerMock.mockResolvedValue('You have cancer.');
+
+    const result = await runAgent('Show my injury timeline', 42);
+
+    expect(result).toEqual({
+      answer:
+        'I withheld that response because it stated a diagnosis that is not supported by your recorded information. I can summarize what is actually documented in your journal instead.',
+      citations: [],
+      intent: 'journal',
+    });
+  });
 });

--- a/tests/rag-service.test.ts
+++ b/tests/rag-service.test.ts
@@ -196,6 +196,7 @@ describe('rag service', () => {
 
     expect(checkAnswerSafetyMock).toHaveBeenCalledWith(
       'Based on these symptoms, you may have a torn meniscus.',
+      "Doctor's note: diagnosis of torn meniscus.",
       undefined,
     );
 

--- a/tests/safety-service.test.ts
+++ b/tests/safety-service.test.ts
@@ -236,6 +236,7 @@ describe('checkAnswerSafety', () => {
   it('allows a definite restatement of a diagnosis already in the record', () => {
     const result = checkAnswerSafety(
       'You have an ACL tear from a football injury, first recorded on 2024-01-15.',
+      'Injury: ACL tear, first recorded on 2024-01-15.',
     );
 
     expect(result.allowed).toBe(true);
@@ -244,6 +245,7 @@ describe('checkAnswerSafety', () => {
   it('allows quoting a "Diagnosis:" label from a doctor\'s note', () => {
     const result = checkAnswerSafety(
       "Your medical visit on 2024-01-15 with Dr. Smith noted: Diagnosis: torn meniscus.",
+      "Medical visit 2024-01-15, Dr. Smith. Notes: Diagnosis: torn meniscus.",
     );
 
     expect(result.allowed).toBe(true);
@@ -252,6 +254,41 @@ describe('checkAnswerSafety', () => {
   it('allows a definite "this is" restatement of a recorded condition', () => {
     const result = checkAnswerSafety(
       'This is the fracture you recorded on 2023-06-01, treated with a cast.',
+      'Injury: fracture recorded on 2023-06-01, treated with a cast.',
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  // --- New coverage for #142: definite diagnostic assertions must be grounded in evidence ---
+
+  it('blocks a definite diagnosis that is not supported by the evidence', () => {
+    const result = checkAnswerSafety(
+      'You have cancer.',
+      'Notes: patient reports occasional headaches.',
+    );
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'unsupported_diagnosis',
+      message:
+        'I withheld that response because it stated a diagnosis that is not supported by your recorded information. I can summarize what is actually documented in your journal instead.',
+    });
+  });
+
+  it('blocks a "diagnosis:" style assertion not present in the evidence', () => {
+    const result = checkAnswerSafety(
+      'Diagnosis: arthritis.',
+      'Notes: patient reports knee pain after running.',
+    );
+
+    expect(result.allowed).toBe(false);
+  });
+
+  it('allows an answer with no diagnostic assertion regardless of evidence', () => {
+    const result = checkAnswerSafety(
+      'You recorded physiotherapy on three occasions.',
+      '',
     );
 
     expect(result.allowed).toBe(true);


### PR DESCRIPTION
## Summary
- `checkAnswerSafety` (`src/safety/safety-service.ts`) previously received only the LLM's generated answer text — it had no access to the retrieved chunks or journal record, so it allowed all definite diagnostic statements ("you have X", "diagnosis: X") through unconditionally, whether or not they were actually supported by the journal data.
- It now accepts an `evidence` argument and checks each asserted diagnostic term against it via a new `definiteDiagnosisPatterns` set + `findUngroundedDiagnosisTerm` helper. An unsupported assertion is withheld with `reason: 'unsupported_diagnosis'`. A definite restatement of a diagnosis already present in the evidence is still allowed — that's the app's core journal-summary behavior.
- Wired the already-built context string into both call sites: `rag-service.ts` (retrieved-chunk context) and the journal-intent branch of `ai-agent-orchestrator.ts` (formatted injury record).
- Updated `docs/02-architecture.md` §5.4 and `docs/04-implementation-roadmap.md` to describe the new grounding check and its remaining keyword-based limitation.

## Follow-up filed
- #143 — `CONDITION_KEYWORDS` is a fixed generic-word list, so a specific medical term (e.g. "meniscus", "diabetes") bypasses every pattern in the safety module, including this new grounding check. Filed as urgent/security since it's a concrete, currently-exploitable gap, not folded into this PR since it's a different scope (term coverage vs. grounding).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — 41/41 suites, 210/210 tests
- [x] Added/updated regression tests in `tests/safety-service.test.ts` (grounded vs. unsupported definite assertions), `tests/rag-service.test.ts` (evidence passed through), and `tests/ai-agent-orchestrator.test.ts` (real end-to-end journal-path grounding, unmocked `checkAnswerSafety`)

Fixes #142