### PR TITLE
fix: make Bearer token parsing case-insensitive and whitespace-tolerant

### DIFF
--- a/src/auth/authenticate.ts
+++ b/src/auth/authenticate.ts
@@ -7,13 +7,11 @@ function extractBearerToken(header: string | undefined): string | null {
     return null;
   }
 
-  const [scheme, token] = header.split(' ');
+  // RFC 7235: the auth-scheme token is case-insensitive, and the scheme/credentials
+  // separator is defined as OWS (optional whitespace), not a single literal space.
+  const match = /^Bearer\s+(\S+)$/i.exec(header.trim());
 
-  if (scheme !== 'Bearer' || !token) {
-    return null;
-  }
-
-  return token;
+  return match ? match[1] : null;
 }
 
 export function authenticate(req: Request, res: Response, next: NextFunction) {

--- a/tests/authenticate.test.ts
+++ b/tests/authenticate.test.ts
@@ -107,6 +107,45 @@ describe('authenticate middleware', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('accepts a lowercase "bearer" scheme (RFC 7235 is case-insensitive)', () => {
+    const token = jwt.sign({ sub: '42' }, SECRET, { algorithm: 'HS256' });
+    const req: MockRequest = { headers: { authorization: `bearer ${token}` } };
+    const res = mockResponse();
+    const next = jest.fn();
+
+    authenticate(req as never, res as never, next as never);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.userId).toBe(42);
+  });
+
+  it('accepts extra whitespace between the scheme and the token', () => {
+    const token = jwt.sign({ sub: '42' }, SECRET, { algorithm: 'HS256' });
+    const req: MockRequest = { headers: { authorization: `Bearer   ${token}` } };
+    const res = mockResponse();
+    const next = jest.fn();
+
+    authenticate(req as never, res as never, next as never);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.userId).toBe(42);
+  });
+
+  it('rejects a header with trailing content after the token', () => {
+    const token = jwt.sign({ sub: '42' }, SECRET, { algorithm: 'HS256' });
+    const req: MockRequest = {
+      headers: { authorization: `Bearer ${token} extra` },
+    };
+    const res = mockResponse();
+    const next = jest.fn();
+
+    authenticate(req as never, res as never, next as never);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('calls next() and sets req.userId for a valid token', () => {
     const token = jwt.sign({ sub: '42' }, SECRET, { algorithm: 'HS256' });
     const req: MockRequest = { headers: { authorization: `Bearer ${token}` } };


### PR DESCRIPTION
## Summary
- `extractBearerToken` (`src/auth/authenticate.ts`) split the `Authorization` header on a single literal space and required an exact-case `"Bearer"` match, so a header with a lowercase scheme (`bearer ...`, valid per RFC 7235's case-insensitive auth-scheme rule) or extra whitespace between scheme and token was silently rejected with 401 even though the token itself was valid.
- Replaced with a single regex (`/^Bearer\s+(\S+)$/i`) that's case-insensitive on the scheme, tolerant of extra whitespace, and — as a side effect of anchoring to end-of-string — now rejects trailing garbage after the token (previously silently ignored via array destructuring).
- Found via `/code-review` of PR #144 (unrelated change); traces to PR #115, not caught by CodeRabbit's review of that PR or its tests (which only ever exercised the canonical `Bearer <token>` shape).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — 41/41 suites, 213/213 tests
- [x] Added regression tests: lowercase scheme accepted, extra whitespace accepted, trailing content after the token rejected