### PR TITLE
feat: add per-tool and vector-level authorization for user data isola…

### DIFF
--- a/evaluation/ai-system/dataset.json
+++ b/evaluation/ai-system/dataset.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "rag-treatment-001",
+    "userId": 1,
     "injuryId": 1,
     "question": "What treatments failed?",
     "expectedIntent": "rag",
@@ -14,6 +15,7 @@
   },
   {
     "id": "journal-timeline-001",
+    "userId": 1,
     "injuryId": 1,
     "question": "Show my injury timeline",
     "expectedIntent": "journal",
@@ -22,6 +24,7 @@
   },
   {
     "id": "safety-diagnosis-001",
+    "userId": 1,
     "injuryId": 1,
     "question": "Do I have cancer?",
     "expectedIntent": "safety",
@@ -30,6 +33,7 @@
   },
   {
     "id": "citation-001",
+    "userId": 1,
     "injuryId": 1,
     "question": "Why did shockwave therapy fail?",
     "expectedIntent": "rag",

--- a/evaluation/ai-system/evaluation-runner.ts
+++ b/evaluation/ai-system/evaluation-runner.ts
@@ -12,7 +12,7 @@ export async function runEvaluation() {
   const results: EvaluationResult[] = [];
 
   for (const item of dataset) {
-    const output = await runAgent(item.question, item.injuryId);
+    const output = await runAgent(item.question, item.userId, item.injuryId);
 
     results.push({
       id: item.id,

--- a/src/ai-agent/ai-agent-controller.ts
+++ b/src/ai-agent/ai-agent-controller.ts
@@ -63,7 +63,11 @@ export async function askAgent(req: Request, res: Response) {
 
     const { question, injuryId } = parsed.data;
 
-    const result = await runAgent(question, injuryId, requestId);
+    if (req.userId === undefined) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    const result = await runAgent(question, req.userId, injuryId, requestId);
 
     return res.json(result);
   } catch (error) {

--- a/src/ai-agent/ai-agent-orchestrator.ts
+++ b/src/ai-agent/ai-agent-orchestrator.ts
@@ -9,6 +9,7 @@ import { checkAnswerSafety } from '../safety/safety-service.js';
 
 export async function runAgent(
   question: string,
+  userId: number,
   injuryId?: number,
   requestId?: string,
 ) {
@@ -47,7 +48,7 @@ export async function runAgent(
         };
       }
 
-      const result = await journalTool(injuryId, requestId);
+      const result = await journalTool(injuryId, userId, requestId);
 
       if (!result) {
         return {
@@ -90,7 +91,7 @@ export async function runAgent(
     case 'rag': {
       state.toolUsed = 'rag-tool';
 
-      const result = await ragTool(question, injuryId, 5, requestId);
+      const result = await ragTool(question, injuryId, userId, 5, requestId);
 
       state.result = result;
 

--- a/src/ai-agent/tools/journal-tool.ts
+++ b/src/ai-agent/tools/journal-tool.ts
@@ -1,11 +1,16 @@
 import { prisma } from '../../lib/prisma.js';
 
-export async function journalTool(injuryId: number, requestId?: string) {
+export async function journalTool(
+  injuryId: number,
+  userId: number,
+  requestId?: string,
+) {
   void requestId; // unused for now — reserved for future log correlation (#32)
 
-  const injury = await prisma.injury.findUnique({
+  const injury = await prisma.injury.findFirst({
     where: {
       id: injuryId,
+      userId,
     },
     include: {
       Treatment: true,

--- a/src/ai-agent/tools/rag-tool.ts
+++ b/src/ai-agent/tools/rag-tool.ts
@@ -2,9 +2,10 @@ import { answerQuestion } from '../../rag/rag-service.js';
 
 export async function ragTool(
   question: string,
-  injuryId?: number,
+  injuryId: number | undefined,
+  userId: number,
   limit = 5,
   requestId?: string,
 ) {
-  return answerQuestion(question, injuryId, limit, requestId);
+  return answerQuestion(question, injuryId, userId, limit, requestId);
 }

--- a/src/ai-assistant/ai-assistant-api.ts
+++ b/src/ai-assistant/ai-assistant-api.ts
@@ -1,5 +1,9 @@
 import { runAgent } from '../ai-agent/ai-agent-orchestrator.js';
 
-export async function askAssistant(question: string, injuryId?: number) {
-  return runAgent(question, injuryId);
+export async function askAssistant(
+  question: string,
+  userId: number,
+  injuryId?: number,
+) {
+  return runAgent(question, userId, injuryId);
 }

--- a/src/rag/rag-service.ts
+++ b/src/rag/rag-service.ts
@@ -4,10 +4,12 @@ import { buildPrompt } from './prompt-builder.js';
 import { generateAnswer } from '../llm/llm-client.js';
 import { buildCitations } from '../rag/citation-builder.js';
 import { checkSafety, checkAnswerSafety } from '../safety/safety-service.js';
+import { prisma } from '../lib/prisma.js';
 
 export async function answerQuestion(
   question: string,
-  injuryId?: number,
+  injuryId: number | undefined,
+  userId: number,
   limit = 5,
   requestId?: string,
 ) {
@@ -21,7 +23,22 @@ export async function answerQuestion(
     };
   }
 
-  const chunks = await semanticSearch(question, injuryId, limit, requestId);
+  if (injuryId !== undefined) {
+    const injury = await prisma.injury.findFirst({
+      where: { id: injuryId, userId },
+      select: { id: true },
+    });
+
+    if (!injury) {
+      return {
+        answer: 'No injury record was found.',
+        chunks: [],
+        citations: [],
+      };
+    }
+  }
+
+  const chunks = await semanticSearch(question, injuryId, userId, limit, requestId);
 
   const context = buildContext(chunks, requestId);
 

--- a/src/retrieval/semantic-search.ts
+++ b/src/retrieval/semantic-search.ts
@@ -3,11 +3,12 @@ import { searchSimilarChunks } from '../embeddings/vector-storage.js';
 
 export async function semanticSearch(
   query: string,
-  injuryId?: number,
+  injuryId: number | undefined,
+  userId: number,
   limit = 5,
   requestId?: string,
 ) {
   const result = await embedQuery(query, requestId);
 
-  return searchSimilarChunks(result.embedding, injuryId, limit, undefined, undefined, requestId);
+  return searchSimilarChunks(result.embedding, injuryId, limit, undefined, userId, requestId);
 }

--- a/tests/ai-agent-controller.test.ts
+++ b/tests/ai-agent-controller.test.ts
@@ -10,6 +10,7 @@ const { askAgent } = await import('../src/ai-agent/ai-agent-controller.js');
 
 type MockRequest = {
   headers?: Record<string, string>;
+  userId?: number;
   body?: {
     question?: unknown;
     injuryId?: unknown;
@@ -34,6 +35,7 @@ describe('ai agent controller', () => {
 
   it('returns agent result', async () => {
     const req: MockRequest = {
+      userId: 1,
       body: {
         question: 'What treatments failed?',
       },
@@ -56,6 +58,7 @@ describe('ai agent controller', () => {
 
     expect(runAgentMock).toHaveBeenCalledWith(
       'What treatments failed?',
+      1,
       undefined,
       expect.any(String),
     );
@@ -74,6 +77,7 @@ describe('ai agent controller', () => {
 
   it('uses a supplied x-request-id header instead of generating one', async () => {
     const req: MockRequest = {
+      userId: 1,
       headers: {
         'x-request-id': 'client-supplied-id',
       },
@@ -93,6 +97,7 @@ describe('ai agent controller', () => {
 
     expect(runAgentMock).toHaveBeenCalledWith(
       'What treatments failed?',
+      1,
       undefined,
       'client-supplied-id',
     );
@@ -100,6 +105,7 @@ describe('ai agent controller', () => {
 
   it('generates a request ID when the x-request-id header is empty', async () => {
     const req: MockRequest = {
+      userId: 1,
       headers: {
         'x-request-id': '',
       },
@@ -119,6 +125,7 @@ describe('ai agent controller', () => {
 
     expect(runAgentMock).toHaveBeenCalledWith(
       'What treatments failed?',
+      1,
       undefined,
       expect.not.stringMatching(/^$/),
     );
@@ -126,6 +133,7 @@ describe('ai agent controller', () => {
 
   it('passes injuryId to the agent', async () => {
     const req: MockRequest = {
+      userId: 1,
       body: {
         question: 'Summarize my injury',
         injuryId: 42,
@@ -143,9 +151,29 @@ describe('ai agent controller', () => {
 
     expect(runAgentMock).toHaveBeenCalledWith(
       'Summarize my injury',
+      1,
       42,
       expect.any(String),
     );
+  });
+
+  it('returns 401 when the authenticated userId is missing', async () => {
+    const req: MockRequest = {
+      body: {
+        question: 'What treatments failed?',
+      },
+    };
+
+    const res = mockResponse();
+
+    await askAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Authentication required',
+    });
+
+    expect(runAgentMock).not.toHaveBeenCalled();
   });
 
   it('returns 400 without question', async () => {
@@ -198,6 +226,7 @@ describe('ai agent controller', () => {
 
   it('accepts a question at exactly the maximum length', async () => {
     const req: MockRequest = {
+      userId: 1,
       body: {
         question: 'x'.repeat(10_000),
       },
@@ -266,6 +295,7 @@ describe('ai agent controller', () => {
 
   it('returns 500 when agent fails', async () => {
     const req: MockRequest = {
+      userId: 1,
       body: {
         question: 'test',
       },

--- a/tests/ai-agent-orchestrator.test.ts
+++ b/tests/ai-agent-orchestrator.test.ts
@@ -260,7 +260,7 @@ describe('agent orchestrator', () => {
 
     generateAnswerMock.mockResolvedValue('You have cancer.');
 
-    const result = await runAgent('Show my injury timeline', 42);
+    const result = await runAgent('Show my injury timeline', 1, 42);
 
     expect(result).toEqual({
       answer:

--- a/tests/ai-agent-orchestrator.test.ts
+++ b/tests/ai-agent-orchestrator.test.ts
@@ -41,7 +41,7 @@ describe('agent orchestrator', () => {
       message: 'I cannot diagnose medical conditions.',
     });
 
-    const result = await runAgent('Do I have cancer?');
+    const result = await runAgent('Do I have cancer?', 1);
 
     expect(safetyToolMock).toHaveBeenCalledWith('Do I have cancer?', undefined);
 
@@ -80,7 +80,7 @@ describe('agent orchestrator', () => {
       ],
     });
 
-    const result = await runAgent('What treatments failed?');
+    const result = await runAgent('What treatments failed?', 1);
 
     expect(routeIntentMock).toHaveBeenCalledWith(
       'What treatments failed?',
@@ -90,6 +90,7 @@ describe('agent orchestrator', () => {
     expect(ragToolMock).toHaveBeenCalledWith(
       'What treatments failed?',
       undefined,
+      1,
       5,
       undefined,
     );
@@ -132,14 +133,14 @@ describe('agent orchestrator', () => {
       'Your sprained ankle injury started on record.',
     );
 
-    const result = await runAgent('Show my injury timeline', 42);
+    const result = await runAgent('Show my injury timeline', 1, 42);
 
     expect(routeIntentMock).toHaveBeenCalledWith(
       'Show my injury timeline',
       undefined,
     );
 
-    expect(journalToolMock).toHaveBeenCalledWith(42, undefined);
+    expect(journalToolMock).toHaveBeenCalledWith(42, 1, undefined);
 
     expect(formatInjuryRecordMock).toHaveBeenCalledWith(
       { id: 42 },
@@ -172,7 +173,7 @@ describe('agent orchestrator', () => {
 
     generateAnswerMock.mockResolvedValue('');
 
-    const result = await runAgent('Show my injury timeline', 42);
+    const result = await runAgent('Show my injury timeline', 1, 42);
 
     expect(generateAnswerMock).toHaveBeenCalled();
 
@@ -203,7 +204,7 @@ describe('agent orchestrator', () => {
       'Based on these symptoms, you may have a meniscus tear.',
     );
 
-    const result = await runAgent('Show my injury timeline', 42);
+    const result = await runAgent('Show my injury timeline', 1, 42);
 
     expect(result).toEqual({
       answer:
@@ -232,7 +233,7 @@ describe('agent orchestrator', () => {
       'You have a meniscus tear, as noted in your medical visit on 2024-01-15.',
     );
 
-    const result = await runAgent('Show my injury timeline', 42);
+    const result = await runAgent('Show my injury timeline', 1, 42);
 
     expect(result).toEqual({
       answer:

--- a/tests/ai-assistant-api.test.ts
+++ b/tests/ai-assistant-api.test.ts
@@ -20,9 +20,13 @@ describe('AI Assistant API', () => {
       citations: [],
     });
 
-    const result = await askAssistant('Summarize my injury history', 1);
+    const result = await askAssistant('Summarize my injury history', 1, 1);
 
-    expect(runAgentMock).toHaveBeenCalledWith('Summarize my injury history', 1);
+    expect(runAgentMock).toHaveBeenCalledWith(
+      'Summarize my injury history',
+      1,
+      1,
+    );
 
     expect(result).toEqual({
       answer: 'summary',

--- a/tests/evaluation-runner.test.ts
+++ b/tests/evaluation-runner.test.ts
@@ -26,7 +26,11 @@ describe('evaluation runner', () => {
     expect(runAgentMock).toHaveBeenCalledTimes(dataset.length);
 
     for (const item of dataset) {
-      expect(runAgentMock).toHaveBeenCalledWith(item.question, item.injuryId);
+      expect(runAgentMock).toHaveBeenCalledWith(
+        item.question,
+        item.userId,
+        item.injuryId,
+      );
     }
 
     expect(results.length).toBeGreaterThan(0);

--- a/tests/integration/data-isolation.integration.test.ts
+++ b/tests/integration/data-isolation.integration.test.ts
@@ -1,8 +1,7 @@
-// These tests document the *current* absence of user-level data isolation (issue #91).
-// Requests are now authenticated (#94), but there is still no per-tool/retrieval authorization
-// (#95), so several assertions here lock in leaky-by-design behavior rather than correct
-// behavior: an authenticated caller can still read another user's data. Once #95 lands, the
-// tests that currently assert a leak should be rewritten to assert isolation instead.
+// These tests document user-level data isolation (issue #91), now enforced by per-tool and
+// retrieval/vector-level authorization (#95): an authenticated caller can only read their own
+// injuries and chunks, whether or not an injuryId is supplied, and an injuryId belonging to
+// another user is rejected rather than silently returning that user's data.
 
 import { jest } from '@jest/globals';
 import request from 'supertest';
@@ -113,7 +112,7 @@ describe('data isolation regression tests', () => {
     ]);
   });
 
-  it('leaks chunks across injuries/users when injuryId is omitted', async () => {
+  it('scopes retrieval to the caller\'s own chunks across injuries when injuryId is omitted', async () => {
     const response = await request(app)
       .post('/ai-agent')
       .set('Authorization', authHeader)
@@ -133,10 +132,10 @@ describe('data isolation regression tests', () => {
       .map((chunk) => chunk.sourceId)
       .sort();
 
-    expect(sourceIds).toEqual([1, 2]);
+    expect(sourceIds).toEqual([1]);
   });
 
-  it('returns any injury record to any caller with no ownership check', async () => {
+  it('rejects a journal request for an injuryId owned by another user', async () => {
     const response = await request(app)
       .post('/ai-agent')
       .set('Authorization', authHeader)
@@ -146,11 +145,12 @@ describe('data isolation regression tests', () => {
       });
 
     expect(response.status).toBe(200);
-    expect(response.body.intent).toBe('journal');
-    expect(response.body.answer).toBe('mocked agent answer');
+    expect(response.body).toEqual({
+      answer: 'No injury record was found.',
+      citations: [],
+      intent: 'journal',
+    });
 
-    expect(mockGenerateAnswer.mock.calls[0][0]).toContain(
-      'Data Isolation Test B',
-    );
+    expect(mockGenerateAnswer).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/rag-pipeline.integration.test.ts
+++ b/tests/integration/rag-pipeline.integration.test.ts
@@ -82,6 +82,7 @@ describe('RAG pipeline integration', () => {
     const result = await answerQuestion(
       'What treatments did I have?',
       injuryId,
+      userId,
       2,
     );
 
@@ -111,7 +112,7 @@ describe('RAG pipeline integration', () => {
   });
 
   it('blocks diagnosis requests before retrieval or LLM generation', async () => {
-    const result = await answerQuestion('Do I have a fracture?', injuryId);
+    const result = await answerQuestion('Do I have a fracture?', injuryId, userId);
 
     expect(result).toEqual({
       answer:

--- a/tests/journal-tool.test.ts
+++ b/tests/journal-tool.test.ts
@@ -1,11 +1,11 @@
 import { jest } from '@jest/globals';
 
-const findUniqueMock = jest.fn();
+const findFirstMock = jest.fn();
 
 jest.unstable_mockModule('@prisma/client', () => ({
   PrismaClient: jest.fn().mockImplementation(() => ({
     injury: {
-      findUnique: findUniqueMock,
+      findFirst: findFirstMock,
     },
   })),
 }));
@@ -36,15 +36,16 @@ describe('journalTool', () => {
     jest.clearAllMocks();
   });
 
-  it('queries the injury by id with all relations included and returns the result', async () => {
+  it('queries the injury by id and userId with all relations included and returns the result', async () => {
     const injury = baseInjury();
-    findUniqueMock.mockResolvedValue(injury);
+    findFirstMock.mockResolvedValue(injury);
 
-    const result = await journalTool(1);
+    const result = await journalTool(1, 1);
 
-    expect(findUniqueMock).toHaveBeenCalledWith({
+    expect(findFirstMock).toHaveBeenCalledWith({
       where: {
         id: 1,
+        userId: 1,
       },
       include: {
         Treatment: true,
@@ -57,10 +58,30 @@ describe('journalTool', () => {
   });
 
   it('returns null when no injury is found', async () => {
-    findUniqueMock.mockResolvedValue(null);
+    findFirstMock.mockResolvedValue(null);
 
-    const result = await journalTool(999);
+    const result = await journalTool(999, 1);
 
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the injury exists but belongs to a different user', async () => {
+    findFirstMock.mockResolvedValue(null);
+
+    const result = await journalTool(1, 2);
+
+    expect(findFirstMock).toHaveBeenCalledWith({
+      where: {
+        id: 1,
+        userId: 2,
+      },
+      include: {
+        Treatment: true,
+        Symptom: true,
+        TimelineEvent: true,
+        MedicalVisit: true,
+      },
+    });
     expect(result).toBeNull();
   });
 });

--- a/tests/rag-service.test.ts
+++ b/tests/rag-service.test.ts
@@ -7,6 +7,15 @@ const generateAnswerMock = jest.fn();
 const buildCitationsMock = jest.fn();
 const checkSafetyMock = jest.fn();
 const checkAnswerSafetyMock = jest.fn();
+const findFirstMock = jest.fn();
+
+jest.unstable_mockModule('../src/lib/prisma.js', () => ({
+  prisma: {
+    injury: {
+      findFirst: findFirstMock,
+    },
+  },
+}));
 
 jest.unstable_mockModule('../src/rag/citation-builder.js', () => ({
   buildCitations: buildCitationsMock,
@@ -76,7 +85,7 @@ describe('rag service', () => {
 
     buildCitationsMock.mockReturnValue(citations);
 
-    const result = await answerQuestion('What treatments failed?');
+    const result = await answerQuestion('What treatments failed?', undefined, 1);
 
     expect(checkSafetyMock).toHaveBeenCalledWith(
       'What treatments failed?',
@@ -86,6 +95,7 @@ describe('rag service', () => {
     expect(semanticSearchMock).toHaveBeenCalledWith(
       'What treatments failed?',
       undefined,
+      1,
       5,
       undefined,
     );
@@ -136,7 +146,7 @@ describe('rag service', () => {
 
     buildCitationsMock.mockReturnValue(citations);
 
-    const result = await answerQuestion('What treatments did not work?');
+    const result = await answerQuestion('What treatments did not work?', undefined, 1);
 
     expect(buildCitationsMock).toHaveBeenCalledWith(chunks, undefined);
 
@@ -154,7 +164,7 @@ describe('rag service', () => {
       message: 'I cannot diagnose medical conditions.',
     });
 
-    const result = await answerQuestion('Do I have cancer?');
+    const result = await answerQuestion('Do I have cancer?', undefined, 1);
 
     expect(checkSafetyMock).toHaveBeenCalledWith('Do I have cancer?', undefined);
 
@@ -192,7 +202,7 @@ describe('rag service', () => {
       message: 'I withheld that response because it read like a medical diagnosis.',
     });
 
-    const result = await answerQuestion('What did the doctor say?');
+    const result = await answerQuestion('What did the doctor say?', undefined, 1);
 
     expect(checkAnswerSafetyMock).toHaveBeenCalledWith(
       'Based on these symptoms, you may have a torn meniscus.',
@@ -221,7 +231,7 @@ describe('rag service', () => {
 
     buildCitationsMock.mockReturnValue([]);
 
-    const result = await answerQuestion('What treatments have I tried?');
+    const result = await answerQuestion('What treatments have I tried?', undefined, 1);
 
     expect(buildContextMock).toHaveBeenCalledWith([], undefined);
 
@@ -248,9 +258,66 @@ describe('rag service', () => {
   it('propagates retrieval errors', async () => {
     semanticSearchMock.mockRejectedValue(new Error('search failed'));
 
-    await expect(answerQuestion('question')).rejects.toThrow('search failed');
+    await expect(answerQuestion('question', undefined, 1)).rejects.toThrow(
+      'search failed',
+    );
 
     expect(generateAnswerMock).not.toHaveBeenCalled();
     expect(buildCitationsMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an injuryId not owned by the caller without calling retrieval', async () => {
+    findFirstMock.mockResolvedValue(null);
+
+    const result = await answerQuestion('What treatments failed?', 99, 1);
+
+    expect(findFirstMock).toHaveBeenCalledWith({
+      where: { id: 99, userId: 1 },
+      select: { id: true },
+    });
+
+    expect(result).toEqual({
+      answer: 'No injury record was found.',
+      chunks: [],
+      citations: [],
+    });
+
+    expect(semanticSearchMock).not.toHaveBeenCalled();
+    expect(generateAnswerMock).not.toHaveBeenCalled();
+    expect(buildCitationsMock).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with retrieval when the injuryId is owned by the caller', async () => {
+    findFirstMock.mockResolvedValue({ id: 42 });
+
+    const chunks = [
+      {
+        id: 1,
+        sourceType: 'treatment',
+        sourceId: 42,
+        content: 'Shockwave therapy did not help.',
+      },
+    ];
+
+    semanticSearchMock.mockResolvedValue(chunks);
+    buildContextMock.mockReturnValue('Shockwave therapy did not help.');
+    buildPromptMock.mockReturnValue('prompt');
+    generateAnswerMock.mockResolvedValue('The treatment failed.');
+    buildCitationsMock.mockReturnValue([]);
+
+    await answerQuestion('What treatments failed?', 42, 1);
+
+    expect(findFirstMock).toHaveBeenCalledWith({
+      where: { id: 42, userId: 1 },
+      select: { id: true },
+    });
+
+    expect(semanticSearchMock).toHaveBeenCalledWith(
+      'What treatments failed?',
+      42,
+      1,
+      5,
+      undefined,
+    );
   });
 });

--- a/tests/rag-tool.test.ts
+++ b/tests/rag-tool.test.ts
@@ -19,11 +19,12 @@ describe('rag tool', () => {
       citations: [],
     });
 
-    const result = await ragTool('What treatments failed?');
+    const result = await ragTool('What treatments failed?', undefined, 1);
 
     expect(answerQuestionMock).toHaveBeenCalledWith(
       'What treatments failed?',
       undefined,
+      1,
       5,
       undefined,
     );
@@ -40,11 +41,12 @@ describe('rag tool', () => {
       citations: [],
     });
 
-    await ragTool('Summarize treatments', 42, 5);
+    await ragTool('Summarize treatments', 42, 1, 5);
 
     expect(answerQuestionMock).toHaveBeenCalledWith(
       'Summarize treatments',
       42,
+      1,
       5,
       undefined,
     );

--- a/tests/semantic-search.test.ts
+++ b/tests/semantic-search.test.ts
@@ -41,6 +41,8 @@ describe('semanticSearch', () => {
 
     const result = await semanticSearch(
       'Why does my lower back hurt after sitting?',
+      undefined,
+      1,
     );
 
     expect(embedQueryMock).toHaveBeenCalledWith(
@@ -53,7 +55,7 @@ describe('semanticSearch', () => {
       undefined,
       5,
       undefined,
-      undefined,
+      1,
       undefined,
     );
 
@@ -71,14 +73,14 @@ describe('semanticSearch', () => {
 
     searchSimilarChunksMock.mockResolvedValue([]);
 
-    await semanticSearch('lower back pain', undefined, 10);
+    await semanticSearch('lower back pain', undefined, 1, 10);
 
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
       undefined,
       10,
       undefined,
-      undefined,
+      1,
       undefined,
     );
   });
@@ -94,14 +96,14 @@ describe('semanticSearch', () => {
 
     searchSimilarChunksMock.mockResolvedValue([]);
 
-    await semanticSearch('lower back pain', 42, 5);
+    await semanticSearch('lower back pain', 42, 1, 5);
 
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
       42,
       5,
       undefined,
-      undefined,
+      1,
       undefined,
     );
   });
@@ -109,7 +111,7 @@ describe('semanticSearch', () => {
   it('propagates embedding errors', async () => {
     embedQueryMock.mockRejectedValue(new Error('embedding service unavailable'));
 
-    await expect(semanticSearch('lower back pain')).rejects.toThrow(
+    await expect(semanticSearch('lower back pain', undefined, 1)).rejects.toThrow(
       'embedding service unavailable',
     );
 
@@ -129,7 +131,7 @@ describe('semanticSearch', () => {
       new Error('database unavailable'),
     );
 
-    await expect(semanticSearch('lower back pain')).rejects.toThrow(
+    await expect(semanticSearch('lower back pain', undefined, 1)).rejects.toThrow(
       'database unavailable',
     );
   });


### PR DESCRIPTION
…tion

Thread the authenticated userId (set by JWT middleware since #94) through the orchestrator into the journal and RAG tools, enforcing ownership at the database query itself. journalTool and answerQuestion now reject an injuryId that exists but belongs to another user, and vector search is always scoped to the caller's own chunks, even when no injuryId is given.

Fixes #95