### PR TITLE
fix: expand CONDITION_KEYWORDS with terms bypassing safety patterns

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -306,9 +306,10 @@ flowchart TD
 > asserted term does not appear anywhere in that evidence (issue #142) — a definite restatement
 > of a diagnosis already in the record is still allowed, since that's the app's core
 > journal-summary behavior. This grounding check is still keyword-based: a diagnostic statement
-> using a specific medical term outside `CONDITION_KEYWORDS` (e.g. "meniscus", "ACL") is
-> invisible to it, same as every other pattern in this module (tracked separately as a
-> pre-existing coverage gap).
+> using a specific medical term outside `CONDITION_KEYWORDS` is invisible to it, same as every
+> other pattern in this module. `CONDITION_KEYWORDS` was expanded with several known-bypassing
+> terms (issue #143), but the list remains finite and hand-maintained; closing the gap for
+> arbitrary open-vocabulary terms is tracked under #140 (guardrails framework evaluation).
 
 ### 5.5. AI Agent Architecture
 

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -98,6 +98,10 @@ issues — a security gap-analysis pass also surfaced items #31's own text never
   allowing them through unconditionally. Still keyword-based (`CONDITION_KEYWORDS`), so a
   specific medical term outside that list is still invisible to the check — tracked separately
   as a pre-existing coverage gap. (#142)
+- [x] Expand `CONDITION_KEYWORDS` with specific terms (meniscus, ACL/MCL/PCL/LCL, sciatica,
+  pneumonia, diabetes) identified as bypassing every pattern in `safety-service.ts`. The list
+  remains finite and hand-maintained — arbitrary open-vocabulary terms still bypass every
+  check; closing that structurally is tracked under #140. (#143)
 
 *Optional (safe to defer indefinitely):*
 - [ ] Add helmet + CORS security headers — low value until a real deployed origin/frontend exists. (#97)

--- a/src/safety/safety-service.ts
+++ b/src/safety/safety-service.ts
@@ -13,7 +13,7 @@ export type SafetyResult =
 // treat this regex layer as a fast pre-filter, not the sole safety boundary. The downstream
 // LLM must also be instructed never to diagnose, regardless of how the question is phrased.
 export const CONDITION_KEYWORDS =
-  'injury|condition|disease|syndrome|disorder|diagnosis|tear|fracture|cancer|tumou?r|disc|herniation|infection|concussion|arthritis';
+  'injury|condition|disease|syndrome|disorder|diagnosis|tear|fracture|cancer|tumou?r|disc|herniation|infection|concussion|arthritis|meniscus|acl|mcl|pcl|lcl|sciatica|pneumonia|diabetes';
 
 const diagnosisPatterns = [
   // "Do I have X" — only allow a short qualifier (article + up to 2 words) between the verb

--- a/tests/safety-service.test.ts
+++ b/tests/safety-service.test.ts
@@ -184,6 +184,23 @@ describe('safety service', () => {
       expect(checkSafety(question).allowed).toBe(false);
     });
   });
+
+  // --- Coverage for specific terms outside the original generic keyword set (#143) ---
+
+  it('blocks diagnosis requests naming a specific term not in the original keyword set', () => {
+    const questions = [
+      'Do I have a meniscus tear?',
+      'Do I have an ACL injury?',
+      'Do I have sciatica?',
+      'Do I have pneumonia?',
+      'Do I have diabetes?',
+      'Is this sciatica?',
+    ];
+
+    questions.forEach((question) => {
+      expect(checkSafety(question).allowed).toBe(false);
+    });
+  });
 });
 
 describe('checkAnswerSafety', () => {
@@ -289,6 +306,38 @@ describe('checkAnswerSafety', () => {
     const result = checkAnswerSafety(
       'You recorded physiotherapy on three occasions.',
       '',
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  // --- Coverage for specific terms outside the original generic keyword set (#143) ---
+
+  it('blocks a hedged diagnosis naming a specific term not in the original keyword set', () => {
+    expect(
+      checkAnswerSafety('Based on these symptoms, you may have diabetes.')
+        .allowed,
+    ).toBe(false);
+  });
+
+  it('blocks an ungrounded definite diagnosis naming a specific term not in the original keyword set', () => {
+    const result = checkAnswerSafety(
+      'You have sciatica.',
+      'Notes: patient reports occasional headaches.',
+    );
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'unsupported_diagnosis',
+      message:
+        'I withheld that response because it stated a diagnosis that is not supported by your recorded information. I can summarize what is actually documented in your journal instead.',
+    });
+  });
+
+  it('allows a grounded definite diagnosis naming a specific term not in the original keyword set', () => {
+    const result = checkAnswerSafety(
+      'You have a meniscus tear, first recorded on 2024-01-15.',
+      'Injury: meniscus tear, first recorded on 2024-01-15.',
     );
 
     expect(result.allowed).toBe(true);


### PR DESCRIPTION
## Summary
- Expands `CONDITION_KEYWORDS` in `src/safety/safety-service.ts` with meniscus, ACL/MCL/PCL/LCL, sciatica, pneumonia, and diabetes — specific terms identified as bypassing every regex-based safety pattern (input-side diagnosis requests, output-side hedged-leak detection, and the sabrahermassi/injury-journal-ai#142 evidence-grounding check), since all three pattern arrays share this one constant.
- Updates `docs/02-architecture.md` §5.4 and `docs/04-implementation-roadmap.md` to reflect the expanded coverage and reference sabrahermassi/injury_journal#72 as the tracked structural fix for the remaining open-vocabulary gap.
- Posted findings to sabrahermassi/injury_journal#72 tying this concrete bypass to its long-term-fix scope.

Note: this is a mitigation, not a full close of the underlying problem — the list remains finite and hand-maintained, so any term not added here still bypasses every check. That residual is what sabrahermassi/injury_journal#72 (guardrails framework evaluation) is scoped to address.

Fixes sabrahermassi/injury-journal-ai#143

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (218/218 passing, including the evaluation harness tests)
- [x] New tests cover the newly-added terms on both input-side (`checkSafety`) and output-side (hedged leak + grounded/ungrounded definite diagnosis via `checkAnswerSafety`)