### PR TITLE
feat: require a shared API key on the embedding service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 DATABASE_URL=
 LLM_API_KEY=
+# Required. Shared secret sent as a Bearer token to the embedding service
+# (src/embeddings/embedding_api.py) and must also be set in that service's
+# own process environment.
 EMBEDDING_API_KEY=
 JWT_SECRET=
 # Optional. Comma-separated list of allowed CORS origins. Leave unset until a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testing_injury_ai?schema=public
       JWT_SECRET: ci-test-only-jwt-secret
+      EMBEDDING_API_KEY: ci-test-only-embedding-key
 
     steps:
       - name: Checkout repository
@@ -51,6 +52,7 @@ jobs:
         run: |
           echo "DATABASE_URL=$DATABASE_URL" > .env.test
           echo "JWT_SECRET=$JWT_SECRET" >> .env.test
+          echo "EMBEDDING_API_KEY=$EMBEDDING_API_KEY" >> .env.test
           npx prisma db push
           npx prisma db seed
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Set the following environment variables (see `.env.example` for a starting point
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
 | `GROQ_API_KEY` | Yes | Used by `src/llm/llm-client.ts` for answer generation |
 | `JWT_SECRET` | Yes | Shared secret used to verify `Bearer` JWTs on `POST /ai-agent` (`src/auth/authenticate.ts`); tokens are expected to be issued by the separate journal application, not this backend |
+| `EMBEDDING_API_KEY` | Yes | Shared secret sent as a `Bearer` token to the embedding service (`src/embeddings/embedding-client.ts`); the same value must be set in the embedding service's own process environment (see below) |
 | `EMBEDDING_API_URL` | No | Defaults to `http://127.0.0.1:8000` |
 | `EMBEDDING_API_TIMEOUT_MS` | No | Defaults to 30000 |
 | `PORT` | No | Defaults to 3000 |
@@ -111,8 +112,12 @@ exposing `/embed` and `/embed-batch`) on whatever host/port `EMBEDDING_API_URL` 
 
 ```bash
 pip install -r src/embeddings/requirements.txt
-uvicorn src.embeddings.embedding_api:app --port 8000
+EMBEDDING_API_KEY=<same value as the backend's .env> uvicorn src.embeddings.embedding_api:app --port 8000
 ```
+
+`EMBEDDING_API_KEY` must be set in this process's own environment — it is a separate Python
+process and does not read the Node backend's `.env` file. Every request must include
+`Authorization: Bearer <EMBEDDING_API_KEY>`; the service rejects requests without it.
 
 ### Run the backend
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -505,10 +505,10 @@ flowchart TD
   personal medical/injury data — to Groq's API (`src/llm/llm-client.ts`). No data-retention or
   minimization control exists today; this is accepted as a tradeoff of using a third-party LLM
   provider, not yet mitigated. Tracked as issue #117 (decide accept-as-is vs. minimization).
-- **Embedding service has no auth boundary:** `EMBEDDING_API_URL` (the Python/FastAPI service)
-  has no authentication. Acceptable only while strictly localhost-bound; must be revisited before
-  any deployment step (#33/#34) exposes it beyond localhost. Out of scope for #94/#95, which only
-  cover `/ai-agent`. Tracked as issue #118.
+- **Embedding service auth (#118):** Resolved. `EMBEDDING_API_URL` (the Python/FastAPI service)
+  now requires a shared `EMBEDDING_API_KEY` sent as a `Bearer` token, verified via a FastAPI
+  dependency (`verify_api_key` in `embedding_api.py`) with a constant-time comparison, and fails
+  closed (500) if the key isn't configured. `embedding-client.ts` sends the key on every request.
 
 ## 11. Architectural Decision Log
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -509,6 +509,8 @@ flowchart TD
   now requires a shared `EMBEDDING_API_KEY` sent as a `Bearer` token, verified via a FastAPI
   dependency (`verify_api_key` in `embedding_api.py`) with a constant-time comparison, and fails
   closed (500) if the key isn't configured. `embedding-client.ts` sends the key on every request.
+  The service's `/docs`, `/redoc`, and `/openapi.json` are also disabled, since FastAPI's
+  app-level `dependencies` list doesn't cover those auto-generated routes.
 
 ## 11. Architectural Decision Log
 

--- a/src/embeddings/embedding-client.ts
+++ b/src/embeddings/embedding-client.ts
@@ -65,6 +65,12 @@ async function postEmbedding(
   path: string,
   text: string,
 ): Promise<EmbeddingResponse> {
+  const apiKey = process.env.EMBEDDING_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('EMBEDDING_API_KEY is not configured');
+  }
+
   const controller = new AbortController();
 
   const timeout = setTimeout(
@@ -77,6 +83,7 @@ async function postEmbedding(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({ text }),
       signal: controller.signal,

--- a/src/embeddings/embedding_api.py
+++ b/src/embeddings/embedding_api.py
@@ -1,11 +1,29 @@
-from fastapi import FastAPI
+import os
+import secrets
+
+from fastapi import Depends, FastAPI, Header
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
 from .embedding_service import EmbeddingService
 
 
-app = FastAPI()
+def verify_api_key(authorization: str | None = Header(default=None)) -> None:
+    expected_key = os.environ.get("EMBEDDING_API_KEY")
+
+    if not expected_key:
+        raise HTTPException(
+            status_code=500,
+            detail="EMBEDDING_API_KEY is not configured",
+        )
+
+    scheme, _, token = (authorization or "").partition(" ")
+
+    if scheme != "Bearer" or not token or not secrets.compare_digest(token, expected_key):
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
+app = FastAPI(dependencies=[Depends(verify_api_key)])
 
 embedding_service = EmbeddingService()
 

--- a/src/embeddings/embedding_api.py
+++ b/src/embeddings/embedding_api.py
@@ -23,7 +23,12 @@ def verify_api_key(authorization: str | None = Header(default=None)) -> None:
         raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
 
-app = FastAPI(dependencies=[Depends(verify_api_key)])
+app = FastAPI(
+    dependencies=[Depends(verify_api_key)],
+    openapi_url=None,
+    docs_url=None,
+    redoc_url=None,
+)
 
 embedding_service = EmbeddingService()
 

--- a/src/embeddings/test_embedding_api_unit.py
+++ b/src/embeddings/test_embedding_api_unit.py
@@ -281,39 +281,60 @@ class TestEmbedBatchEndpoint:
         assert response.status_code == 200
 
 
+ENDPOINTS = [
+    ("/embed", {"text": "hello"}),
+    ("/embed-query", {"text": "hello"}),
+    ("/embed-batch", {"texts": ["hello"]}),
+]
+
+
 class TestAuthentication:
+    @pytest.mark.parametrize("path,payload", ENDPOINTS)
     def test_rejects_request_with_no_authorization_header(
-        self, api_module, fake_service
+        self, api_module, fake_service, path, payload
     ):
         unauthenticated_client = TestClient(api_module.app)
 
-        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+        response = unauthenticated_client.post(path, json=payload)
 
         assert response.status_code == 401
         assert fake_service.embed_document_calls == []
+        assert fake_service.embed_query_calls == []
+        assert fake_service.embed_batch_calls == []
 
-    def test_rejects_request_with_wrong_key(self, api_module, fake_service):
+    @pytest.mark.parametrize("path,payload", ENDPOINTS)
+    def test_rejects_request_with_wrong_key(
+        self, api_module, fake_service, path, payload
+    ):
         unauthenticated_client = TestClient(
             api_module.app, headers={"Authorization": "Bearer wrong-key"}
         )
 
-        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+        response = unauthenticated_client.post(path, json=payload)
 
         assert response.status_code == 401
         assert fake_service.embed_document_calls == []
+        assert fake_service.embed_query_calls == []
+        assert fake_service.embed_batch_calls == []
 
-    def test_rejects_request_with_non_bearer_scheme(self, api_module, fake_service):
+    @pytest.mark.parametrize("path,payload", ENDPOINTS)
+    def test_rejects_request_with_non_bearer_scheme(
+        self, api_module, fake_service, path, payload
+    ):
         unauthenticated_client = TestClient(
             api_module.app, headers={"Authorization": TEST_API_KEY}
         )
 
-        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+        response = unauthenticated_client.post(path, json=payload)
 
         assert response.status_code == 401
         assert fake_service.embed_document_calls == []
+        assert fake_service.embed_query_calls == []
+        assert fake_service.embed_batch_calls == []
 
+    @pytest.mark.parametrize("path,payload", ENDPOINTS)
     def test_fails_closed_when_api_key_is_not_configured(
-        self, api_module, fake_service, monkeypatch
+        self, api_module, fake_service, monkeypatch, path, payload
     ):
         monkeypatch.delenv("EMBEDDING_API_KEY", raising=False)
 
@@ -321,7 +342,26 @@ class TestAuthentication:
             api_module.app, headers={"Authorization": f"Bearer {TEST_API_KEY}"}
         )
 
-        response = unconfigured_client.post("/embed", json={"text": "hello"})
+        response = unconfigured_client.post(path, json=payload)
 
         assert response.status_code == 500
         assert fake_service.embed_document_calls == []
+        assert fake_service.embed_query_calls == []
+        assert fake_service.embed_batch_calls == []
+
+
+class TestDocsDisabled:
+    def test_openapi_json_is_disabled(self, client):
+        response = client.get("/openapi.json")
+
+        assert response.status_code == 404
+
+    def test_docs_ui_is_disabled(self, client):
+        response = client.get("/docs")
+
+        assert response.status_code == 404
+
+    def test_redoc_ui_is_disabled(self, client):
+        response = client.get("/redoc")
+
+        assert response.status_code == 404

--- a/src/embeddings/test_embedding_api_unit.py
+++ b/src/embeddings/test_embedding_api_unit.py
@@ -19,6 +19,8 @@ from fastapi.testclient import TestClient
 
 SRC_DIR = Path(__file__).resolve().parent.parent
 
+TEST_API_KEY = "test-embedding-key"
+
 
 class FakeEncodedVector:
     """Stand-in for the numpy array normally returned by
@@ -89,6 +91,8 @@ def api_module(monkeypatch):
     for name in ("embeddings.embedding_api", "embeddings.embedding_service"):
         monkeypatch.delitem(sys.modules, name, raising=False)
 
+    monkeypatch.setenv("EMBEDDING_API_KEY", TEST_API_KEY)
+
     module = importlib.import_module("embeddings.embedding_api")
 
     yield module
@@ -106,7 +110,9 @@ def fake_service(api_module, monkeypatch):
 
 @pytest.fixture
 def client(api_module, fake_service):
-    return TestClient(api_module.app)
+    return TestClient(
+        api_module.app, headers={"Authorization": f"Bearer {TEST_API_KEY}"}
+    )
 
 
 class TestEmbedEndpoint:
@@ -273,3 +279,49 @@ class TestEmbedBatchEndpoint:
         )
 
         assert response.status_code == 200
+
+
+class TestAuthentication:
+    def test_rejects_request_with_no_authorization_header(
+        self, api_module, fake_service
+    ):
+        unauthenticated_client = TestClient(api_module.app)
+
+        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+
+        assert response.status_code == 401
+        assert fake_service.embed_document_calls == []
+
+    def test_rejects_request_with_wrong_key(self, api_module, fake_service):
+        unauthenticated_client = TestClient(
+            api_module.app, headers={"Authorization": "Bearer wrong-key"}
+        )
+
+        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+
+        assert response.status_code == 401
+        assert fake_service.embed_document_calls == []
+
+    def test_rejects_request_with_non_bearer_scheme(self, api_module, fake_service):
+        unauthenticated_client = TestClient(
+            api_module.app, headers={"Authorization": TEST_API_KEY}
+        )
+
+        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+
+        assert response.status_code == 401
+        assert fake_service.embed_document_calls == []
+
+    def test_fails_closed_when_api_key_is_not_configured(
+        self, api_module, fake_service, monkeypatch
+    ):
+        monkeypatch.delenv("EMBEDDING_API_KEY", raising=False)
+
+        unconfigured_client = TestClient(
+            api_module.app, headers={"Authorization": f"Bearer {TEST_API_KEY}"}
+        )
+
+        response = unconfigured_client.post("/embed", json={"text": "hello"})
+
+        assert response.status_code == 500
+        assert fake_service.embed_document_calls == []

--- a/tests/embedding-client.test.ts
+++ b/tests/embedding-client.test.ts
@@ -77,7 +77,10 @@ describe('embedText', () => {
       'http://127.0.0.1:8000/embed',
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-embedding-key',
+        },
         body: JSON.stringify({ text: 'hello world' }),
       }),
     );
@@ -272,6 +275,22 @@ describe('embedText', () => {
 
     expect(result.embedding).toEqual(TEST_EMBEDDING);
   });
+
+  it('throws without calling fetch when EMBEDDING_API_KEY is not configured', async () => {
+    delete process.env.EMBEDDING_API_KEY;
+
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(makeResponse());
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { embedText } = await loadEmbeddingClient();
+
+    await expect(embedText('hi')).rejects.toThrow(
+      'EMBEDDING_API_KEY is not configured',
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('embedQuery', () => {
@@ -300,7 +319,10 @@ describe('embedQuery', () => {
       'http://127.0.0.1:8000/embed-query',
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-embedding-key',
+        },
         body: JSON.stringify({ text: 'what treatments have I tried?' }),
       }),
     );
@@ -340,5 +362,21 @@ describe('embedQuery', () => {
     await expect(embedQuery('hi')).rejects.toThrow(
       'Embedding API request failed: 500 Internal Server Error',
     );
+  });
+
+  it('throws without calling fetch when EMBEDDING_API_KEY is not configured', async () => {
+    delete process.env.EMBEDDING_API_KEY;
+
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(makeResponse());
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { embedQuery } = await loadEmbeddingClient();
+
+    await expect(embedQuery('hi')).rejects.toThrow(
+      'EMBEDDING_API_KEY is not configured',
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/embedding-client.test.ts
+++ b/tests/embedding-client.test.ts
@@ -53,6 +53,7 @@ describe('embedText', () => {
 
   it('sends a POST request to the default embedding API URL with the expected payload', async () => {
     delete process.env.EMBEDDING_API_URL;
+    process.env.EMBEDDING_API_KEY = 'test-embedding-key';
 
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
       makeResponse({
@@ -306,6 +307,7 @@ describe('embedQuery', () => {
 
   it('sends a POST request to /embed-query, not /embed', async () => {
     delete process.env.EMBEDDING_API_URL;
+    process.env.EMBEDDING_API_KEY = 'test-embedding-key';
 
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(makeResponse());
 


### PR DESCRIPTION
## Summary
- Add a static shared-secret Bearer-token check (`verify_api_key`, constant-time comparison) to `embedding_api.py`, applied to every route via a single FastAPI dependency, failing closed (500) if `EMBEDDING_API_KEY` isn't configured.
- `embedding-client.ts` sends `Authorization: Bearer <EMBEDDING_API_KEY>` on every request and throws before calling out if the key is missing.
- Update `.env.example`, `README.md`, CI env/`.env.test` generation, and `docs/02-architecture.md`'s accepted-risks section to mark #118 resolved.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (224/224)
- [x] `pytest src/embeddings/` (47/47)

Fixes #118