### PR TITLE
fix: handle 'safety' intent in ai-agent orchestrator switch

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -624,16 +624,16 @@ quoted), what else was considered, whether it still holds, and whether it should
   its cost yet — this doc's own §5.5 calls it "an intentional MVP simplification, deferred until
   multi-step workflows justify" the change.
 - **ALTERNATIVES CONSIDERED:** An LLM-driven planner (function-calling / tool-use loop) — more
-  flexible and would remove the keyword-matching brittleness (see the dead `'safety'`
-  `AgentIntent` branch documented in `docs/05-api-contract.md` §3/§5), at the cost of
-  nondeterminism, added latency/cost per request, and a harder-to-evaluate routing step.
-- **CURRENT STATUS:** Still valid for "should we adopt a framework" — but the current
-  implementation has a concrete bug this decision doesn't excuse: `routeIntent()` can return
-  `'safety'`, and the orchestrator's `switch` has no case for it, so those requests silently fall
-  into the generic "unable to determine" response instead of a refusal. That's an implementation
-  defect in the current approach, not a reason to adopt a framework. Filed as issue #86.
-- **SHOULD THIS BE REVISITED:** No, not the framework decision — but the dead `'safety'` branch
-  should be fixed regardless of which routing approach is used long-term (#86).
+  flexible and would remove the keyword-matching brittleness (`routeIntent()`'s narrower
+  `'safety'` keyword list overlaps with, but isn't identical to, `checkSafety`'s more thorough
+  regex set — see `docs/05-api-contract.md` §3/§5), at the cost of nondeterminism, added
+  latency/cost per request, and a harder-to-evaluate routing step.
+- **CURRENT STATUS:** Still valid for "should we adopt a framework." The `routeIntent()` /
+  `'safety'` dead-branch defect noted here previously (issue #86) is fixed: the orchestrator's
+  `switch` now has a `case 'safety'` returning the same diagnosis-refusal message the earlier
+  `checkSafety` gate produces, so a `'safety'`-routed question no longer falls into the generic
+  "unable to determine" response.
+- **SHOULD THIS BE REVISITED:** No.
 
 ### D7 — `POST /rag/ask` retired; `POST /ai-agent` is the sole public entrypoint (resolved)
 

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -171,8 +171,9 @@ product decision that should be made explicitly rather than discovered by omissi
   to the not-yet-built ingestion worker (#40).
 - [x] #61 — `/ai-agent` now returns 400 instead of 500 for a body-less request.
 - [x] #43 — `POST /rag/ask` retired; `POST /ai-agent` is the sole public entrypoint.
-- [ ] #86 — `routeIntent()` can return `'safety'`, but the orchestrator's `switch` has no case for
-  it (falls into the generic default response instead of a refusal). Surfaced while resolving #43.
+- [x] #86 — `routeIntent()` can return `'safety'`; the orchestrator's `switch` now has a
+  `case 'safety'` that returns the same diagnosis-refusal message as the earlier `checkSafety`
+  gate, instead of falling into the generic default response. Surfaced while resolving #43.
 
 ---
 

--- a/docs/05-api-contract.md
+++ b/docs/05-api-contract.md
@@ -59,18 +59,18 @@ the branch without inferring it from shape (resolved as part of issue #45):**
 | `journal` intent, `injuryId` not found | `{ "answer": "No injury record was found.", "citations": [], "intent": "journal" }` — **no `metadata` key** |
 | `journal` intent, found | `{ "answer": "<LLM-generated prose summary of the injury record>", "citations": [], "intent": "journal" }` — generated via `formatInjuryRecord()` → `buildPrompt()` → `generateAnswer()`; there's still no `metadata` key |
 | `rag` intent | `{ "answer": "string", "citations": [...], "intent": "rag", "metadata": { "retrievedChunks": [{ "sourceType": "string", "sourceId": 1 }] } }` |
-| Unrecognized intent (and see note below) | `{ "answer": "Unable to determine how to handle this request.", "citations": [], "intent": "safety", "metadata": { "retrievedChunks": [] } }` — `intent` here is whatever `routeIntent()` actually returned, which today is only reachable for the `'safety'`-value dead-branch case described below |
+| `safety` intent from `routeIntent()` | `{ "answer": "<refusal>", "citations": [], "intent": "safety", "metadata": { "retrievedChunks": [] } }` — same message/shape as the "Safety-blocked" row above, produced by a second, narrower keyword check (see note below) rather than the main `checkSafety` gate |
 
-**Important internal inconsistency, not just a documentation gap:** `routeIntent()` can return
+**Note — two distinct safety-routing paths, not a documentation gap:** `routeIntent()` can return
 `'safety'` as an `AgentIntent` (it's a defined member of the type and is returned when the
-question matches a small keyword list — `diagnose`, `do i have`, `cancer`, `condition`). But
-`runAgent`'s `switch` has no `case 'safety':` — it only handles `'journal'` and `'rag'`
-explicitly. A `'safety'`-routed question therefore falls into the generic default branch
-("Unable to determine how to handle this request.") instead of a safety refusal. This is separate
-from — and less thorough than — the actual safety gate that already runs earlier in the same
-function (`checkSafety`/`safetyTool`, a much larger regex set in `safety-service.ts`). The two
-mechanisms overlap but are not identical, and only one of them is actually wired to produce a
-refusal response. Tracked as issue #86.
+question matches a small keyword list — `diagnose`, `do i have`, `cancer`, `condition`).
+`runAgent`'s `switch` has a `case 'safety':` that returns the same refusal shape as the main
+safety gate. This is separate from — and less thorough than — the actual safety gate that already
+runs earlier in the same function (`checkSafety`/`safetyTool`, a much larger regex set in
+`safety-service.ts`). The two mechanisms overlap but are not identical: a question that slips past
+`checkSafety` but matches `routeIntent`'s narrower list still gets a proper refusal, just via the
+second path. Reconciling the two keyword sets is out of scope for issue #86, which only closed the
+missing-switch-case defect.
 
 **Errors**
 
@@ -104,9 +104,10 @@ limit of `5` for the `rag` intent path.
 - **The `journal` intent produces an LLM-generated prose answer**, not a structured field-by-field
   breakdown of the record — quality depends on the LLM correctly summarizing the context built by
   `formatInjuryRecord()`.
-- **The dead `'safety'` intent branch** described in §3 — a real inconsistency between the type
-  system (`AgentIntent`) and the orchestrator's actual handling, not just a documentation gap.
-  Tracked as issue #86.
+- **Two overlapping-but-not-identical safety-detection mechanisms** (the main `checkSafety` gate
+  and `routeIntent()`'s narrower keyword list) both feed into the same `'safety'` intent/response
+  shape — see §3. Fixed as issue #86 (the switch previously had no case for the `routeIntent()`
+  path); reconciling the two keyword sets themselves remains unaddressed.
 - **An unused, unwired duplicate entrypoint exists in the codebase**:
   `src/ai-assistant/ai-assistant-api.ts` (a thin, otherwise-unused wrapper around `runAgent`). It is
   not reachable from any route. (`src/ai-agent/ai-agent-service.ts`, a dead duplicate of

--- a/src/ai-agent/ai-agent-orchestrator.ts
+++ b/src/ai-agent/ai-agent-orchestrator.ts
@@ -5,7 +5,10 @@ import { routeIntent } from './ai-agent-intent-router.js';
 import { AgentState } from './ai-agent-state.js';
 import { buildPrompt } from '../rag/prompt-builder.js';
 import { generateAnswer } from '../llm/llm-client.js';
-import { checkAnswerSafety } from '../safety/safety-service.js';
+import {
+  checkAnswerSafety,
+  DIAGNOSIS_REQUEST_MESSAGE,
+} from '../safety/safety-service.js';
 
 export async function runAgent(
   question: string,
@@ -37,6 +40,16 @@ export async function runAgent(
   state.intent = intent;
 
   switch (intent) {
+    case 'safety':
+      return {
+        answer: DIAGNOSIS_REQUEST_MESSAGE,
+        citations: [],
+        intent,
+        metadata: {
+          retrievedChunks: [],
+        },
+      };
+
     case 'journal': {
       state.toolUsed = 'journal-tool';
 

--- a/src/safety/safety-service.ts
+++ b/src/safety/safety-service.ts
@@ -15,6 +15,9 @@ export type SafetyResult =
 export const CONDITION_KEYWORDS =
   'injury|condition|disease|syndrome|disorder|diagnosis|tear|fracture|cancer|tumou?r|disc|herniation|infection|concussion|arthritis|meniscus|acl|mcl|pcl|lcl|sciatica|pneumonia|diabetes';
 
+export const DIAGNOSIS_REQUEST_MESSAGE =
+  'I cannot diagnose medical conditions, but I can help summarize your recorded symptoms, tests, treatments, and medical history.';
+
 const diagnosisPatterns = [
   // "Do I have X" — only allow a short qualifier (article + up to 2 words) between the verb
   // and the keyword, so unrelated context ("old notes about my fracture") isn't swallowed by
@@ -86,8 +89,7 @@ export function checkSafety(question: string, requestId?: string): SafetyResult 
     return {
       allowed: false,
       reason: 'diagnosis_request',
-      message:
-        'I cannot diagnose medical conditions, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
+      message: DIAGNOSIS_REQUEST_MESSAGE,
     };
   }
 

--- a/src/safety/safety-service.ts
+++ b/src/safety/safety-service.ts
@@ -16,7 +16,7 @@ export const CONDITION_KEYWORDS =
   'injury|condition|disease|syndrome|disorder|diagnosis|tear|fracture|cancer|tumou?r|disc|herniation|infection|concussion|arthritis|meniscus|acl|mcl|pcl|lcl|sciatica|pneumonia|diabetes';
 
 export const DIAGNOSIS_REQUEST_MESSAGE =
-  'I cannot diagnose medical conditions, but I can help summarize your recorded symptoms, tests, treatments, and medical history.';
+  'I cannot diagnose medical conditions or identify what condition you may have, but I can help summarize your recorded symptoms, tests, treatments, and medical history.';
 
 const diagnosisPatterns = [
   // "Do I have X" — only allow a short qualifier (article + up to 2 words) between the verb

--- a/tests/ai-agent-orchestrator.test.ts
+++ b/tests/ai-agent-orchestrator.test.ts
@@ -58,6 +58,29 @@ describe('agent orchestrator', () => {
     });
   });
 
+  it('withholds a diagnosis-refusal answer when routeIntent flags a question the safety gate allowed', async () => {
+    safetyToolMock.mockReturnValue({
+      allowed: true,
+    });
+
+    routeIntentMock.mockReturnValue('safety');
+
+    const result = await runAgent('What condition might this be?', 1);
+
+    expect(ragToolMock).not.toHaveBeenCalled();
+    expect(journalToolMock).not.toHaveBeenCalled();
+
+    expect(result).toEqual({
+      answer:
+        'I cannot diagnose medical conditions, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
+      citations: [],
+      intent: 'safety',
+      metadata: {
+        retrievedChunks: [],
+      },
+    });
+  });
+
   it('uses RAG tool for treatment questions', async () => {
     safetyToolMock.mockReturnValue({
       allowed: true,

--- a/tests/ai-agent-orchestrator.test.ts
+++ b/tests/ai-agent-orchestrator.test.ts
@@ -72,7 +72,7 @@ describe('agent orchestrator', () => {
 
     expect(result).toEqual({
       answer:
-        'I cannot diagnose medical conditions, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
+        'I cannot diagnose medical conditions or identify what condition you may have, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
       citations: [],
       intent: 'safety',
       metadata: {

--- a/tests/integration/ai-agent-route.integration.test.ts
+++ b/tests/integration/ai-agent-route.integration.test.ts
@@ -115,7 +115,7 @@ describe('AI agent route integration', () => {
 
     expect(response.body).toEqual({
       answer:
-        'I cannot diagnose medical conditions, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
+        'I cannot diagnose medical conditions or identify what condition you may have, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
       citations: [],
       intent: 'safety',
       metadata: {

--- a/tests/integration/rag-pipeline.integration.test.ts
+++ b/tests/integration/rag-pipeline.integration.test.ts
@@ -116,7 +116,7 @@ describe('RAG pipeline integration', () => {
 
     expect(result).toEqual({
       answer:
-        'I cannot diagnose medical conditions, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
+        'I cannot diagnose medical conditions or identify what condition you may have, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
       chunks: [],
       citations: [],
     });

--- a/tests/safety-service.test.ts
+++ b/tests/safety-service.test.ts
@@ -16,7 +16,7 @@ describe('safety service', () => {
       allowed: false,
       reason: 'diagnosis_request',
       message:
-        'I cannot diagnose medical conditions, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
+        'I cannot diagnose medical conditions or identify what condition you may have, but I can help summarize your recorded symptoms, tests, treatments, and medical history.',
     });
   });
 


### PR DESCRIPTION
## Summary
- `routeIntent()` can return `'safety'` for questions that pass the main `checkSafety` gate but match a narrower keyword list (`diagnose`, `do i have`, `cancer`, `condition`). The orchestrator's `switch` previously had no `case 'safety':`, so those questions silently fell into the generic `"Unable to determine how to handle this request."` default response instead of a proper refusal.
- Added `case 'safety':` to `runAgent`'s switch, returning the same response shape as the earlier `checkSafety` gate.
- Extracted `DIAGNOSIS_REQUEST_MESSAGE` as a shared constant in `safety-service.ts` so both refusal paths stay in sync.
- Updated `docs/02-architecture.md` (D6), `docs/05-api-contract.md` (§3/§5), and `docs/04-implementation-roadmap.md` to describe the fix instead of the previously-documented defect.

Two minor self-review cleanup findings (duplicated safety-refusal response literals, missing `routeIntentMock` assertion in the new test) were filed separately as #151 rather than bundled into this PR.

Fixes #86

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test -- tests/ai-agent-orchestrator.test.ts tests/safety-service.test.ts` — 44/44
- [x] Full `npm test` — 222/223 (one pre-existing, unrelated `app.test.ts` rate-limit timeout flake, confirmed by re-running it alone: 6/6)
- [x] New test covers `routeIntent()` returning `'safety'` after the main gate allows the question, asserting the diagnosis-refusal message instead of the old generic fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Safety-related questions now receive the appropriate diagnosis-refusal response instead of a generic fallback message.
  - Safety responses consistently include empty citations and retrieved-content metadata.

- **Documentation**
  - Updated architecture, API contract, and roadmap documentation to reflect the corrected safety-routing behavior and completed work.

- **Tests**
  - Added coverage confirming safety-routed questions avoid retrieval and journal actions while returning the expected response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->