### PR TITLE
118 embedding service auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 DATABASE_URL=
 LLM_API_KEY=
+# Required. Shared secret sent as a Bearer token to the embedding service
+# (src/embeddings/embedding_api.py) and must also be set in that service's
+# own process environment.
 EMBEDDING_API_KEY=
 JWT_SECRET=
 # Optional. Comma-separated list of allowed CORS origins. Leave unset until a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testing_injury_ai?schema=public
       JWT_SECRET: ci-test-only-jwt-secret
+      EMBEDDING_API_KEY: ci-test-only-embedding-key
 
     steps:
       - name: Checkout repository
@@ -51,6 +52,7 @@ jobs:
         run: |
           echo "DATABASE_URL=$DATABASE_URL" > .env.test
           echo "JWT_SECRET=$JWT_SECRET" >> .env.test
+          echo "EMBEDDING_API_KEY=$EMBEDDING_API_KEY" >> .env.test
           npx prisma db push
           npx prisma db seed
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Set the following environment variables (see `.env.example` for a starting point
 | `DATABASE_URL` | Yes | PostgreSQL connection string |
 | `GROQ_API_KEY` | Yes | Used by `src/llm/llm-client.ts` for answer generation |
 | `JWT_SECRET` | Yes | Shared secret used to verify `Bearer` JWTs on `POST /ai-agent` (`src/auth/authenticate.ts`); tokens are expected to be issued by the separate journal application, not this backend |
+| `EMBEDDING_API_KEY` | Yes | Shared secret sent as a `Bearer` token to the embedding service (`src/embeddings/embedding-client.ts`); the same value must be set in the embedding service's own process environment (see below) |
 | `EMBEDDING_API_URL` | No | Defaults to `http://127.0.0.1:8000` |
 | `EMBEDDING_API_TIMEOUT_MS` | No | Defaults to 30000 |
 | `PORT` | No | Defaults to 3000 |
@@ -111,8 +112,12 @@ exposing `/embed` and `/embed-batch`) on whatever host/port `EMBEDDING_API_URL` 
 
 ```bash
 pip install -r src/embeddings/requirements.txt
-uvicorn src.embeddings.embedding_api:app --port 8000
+EMBEDDING_API_KEY=<same value as the backend's .env> uvicorn src.embeddings.embedding_api:app --port 8000
 ```
+
+`EMBEDDING_API_KEY` must be set in this process's own environment — it is a separate Python
+process and does not read the Node backend's `.env` file. Every request must include
+`Authorization: Bearer <EMBEDDING_API_KEY>`; the service rejects requests without it.
 
 ### Run the backend
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -505,10 +505,10 @@ flowchart TD
   personal medical/injury data — to Groq's API (`src/llm/llm-client.ts`). No data-retention or
   minimization control exists today; this is accepted as a tradeoff of using a third-party LLM
   provider, not yet mitigated. Tracked as issue #117 (decide accept-as-is vs. minimization).
-- **Embedding service has no auth boundary:** `EMBEDDING_API_URL` (the Python/FastAPI service)
-  has no authentication. Acceptable only while strictly localhost-bound; must be revisited before
-  any deployment step (#33/#34) exposes it beyond localhost. Out of scope for #94/#95, which only
-  cover `/ai-agent`. Tracked as issue #118.
+- **Embedding service auth (#118):** Resolved. `EMBEDDING_API_URL` (the Python/FastAPI service)
+  now requires a shared `EMBEDDING_API_KEY` sent as a `Bearer` token, verified via a FastAPI
+  dependency (`verify_api_key` in `embedding_api.py`) with a constant-time comparison, and fails
+  closed (500) if the key isn't configured. `embedding-client.ts` sends the key on every request.
 
 ## 11. Architectural Decision Log
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -509,6 +509,8 @@ flowchart TD
   now requires a shared `EMBEDDING_API_KEY` sent as a `Bearer` token, verified via a FastAPI
   dependency (`verify_api_key` in `embedding_api.py`) with a constant-time comparison, and fails
   closed (500) if the key isn't configured. `embedding-client.ts` sends the key on every request.
+  The service's `/docs`, `/redoc`, and `/openapi.json` are also disabled, since FastAPI's
+  app-level `dependencies` list doesn't cover those auto-generated routes.
 
 ## 11. Architectural Decision Log
 

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -153,8 +153,10 @@ product decision that should be made explicitly rather than discovered by omissi
   `GET /injuries` (list), login/session endpoints, a `GET /me` identity endpoint. (#50)
 - [ ] Either way: a conversation/thread concept for the assistant (currently fully stateless,
   one question in, one answer out — no way to thread multi-turn context server-side). (#51)
-- [ ] Either way: decide on streaming vs. full-response for the LLM call before frontend work
-  commits to one UX pattern. (#52)
+- [x] Either way: decide on streaming vs. full-response for the LLM call before frontend work
+  commits to one UX pattern. Decided: stay full-response/buffered — no frontend consumer exists
+  yet, and citations depend on the complete answer, not a token stream. Revisit once a frontend is
+  built if latency becomes a real UX problem. (#52)
 
 **Surfaced during the docs-accuracy review (PR #53), tracked but not yet in this list:**
 

--- a/docs/04-implementation-roadmap.md
+++ b/docs/04-implementation-roadmap.md
@@ -155,8 +155,8 @@ product decision that should be made explicitly rather than discovered by omissi
   one question in, one answer out — no way to thread multi-turn context server-side). (#51)
 - [x] Either way: decide on streaming vs. full-response for the LLM call before frontend work
   commits to one UX pattern. Decided: stay full-response/buffered — no frontend consumer exists
-  yet, and citations depend on the complete answer, not a token stream. Revisit once a frontend is
-  built if latency becomes a real UX problem. (#52)
+  yet to justify the added complexity of streaming. Revisit once a frontend is built if latency
+  becomes a real UX problem. (#52)
 
 **Surfaced during the docs-accuracy review (PR #53), tracked but not yet in this list:**
 

--- a/docs/05-api-contract.md
+++ b/docs/05-api-contract.md
@@ -144,10 +144,10 @@ This is the most important section — these are gaps, not just documentation de
   conversation UI without the frontend re-sending full context itself (and there's currently no
   mechanism to do even that).
 - **Streaming.** Evaluated and deliberately deferred (#52): the LLM call stays fully buffered
-  (`generateAnswer` awaits the entire completion) and the response contract is a single JSON
-  object. No frontend consumer exists yet to justify the added complexity, and citations are
-  derived from the complete answer, not individual tokens. Revisit if/when a frontend is built and
-  latency proves to be a real UX problem.
+  (`generateAnswer` awaits the entire completion), and the endpoint returns one completed answer
+  together with its chunk-derived citations in a single JSON object. No frontend consumer exists
+  yet to justify the added complexity of streaming. Revisit if/when a frontend is built and latency
+  proves to be a real UX problem.
 - **An explicit groundedness/confidence signal.** CLAUDE.md's stated priority — prefer an
   explicit lack-of-information response over an unsupported plausible answer — is enforced only
   as a soft instruction inside the LLM prompt (`prompt-builder.ts`), not as a structural check or

--- a/docs/05-api-contract.md
+++ b/docs/05-api-contract.md
@@ -143,8 +143,11 @@ This is the most important section — these are gaps, not just documentation de
 - **Conversation/thread state.** Every call is fully stateless — no way to support a multi-turn
   conversation UI without the frontend re-sending full context itself (and there's currently no
   mechanism to do even that).
-- **Streaming.** The LLM call is fully buffered (`generateAnswer` awaits the entire completion)
-  before any response is returned — no partial/streaming UX is possible today.
+- **Streaming.** Evaluated and deliberately deferred (#52): the LLM call stays fully buffered
+  (`generateAnswer` awaits the entire completion) and the response contract is a single JSON
+  object. No frontend consumer exists yet to justify the added complexity, and citations are
+  derived from the complete answer, not individual tokens. Revisit if/when a frontend is built and
+  latency proves to be a real UX problem.
 - **An explicit groundedness/confidence signal.** CLAUDE.md's stated priority — prefer an
   explicit lack-of-information response over an unsupported plausible answer — is enforced only
   as a soft instruction inside the LLM prompt (`prompt-builder.ts`), not as a structural check or

--- a/src/embeddings/embedding-client.ts
+++ b/src/embeddings/embedding-client.ts
@@ -65,6 +65,12 @@ async function postEmbedding(
   path: string,
   text: string,
 ): Promise<EmbeddingResponse> {
+  const apiKey = process.env.EMBEDDING_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('EMBEDDING_API_KEY is not configured');
+  }
+
   const controller = new AbortController();
 
   const timeout = setTimeout(
@@ -77,6 +83,7 @@ async function postEmbedding(
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({ text }),
       signal: controller.signal,

--- a/src/embeddings/embedding_api.py
+++ b/src/embeddings/embedding_api.py
@@ -1,11 +1,29 @@
-from fastapi import FastAPI
+import os
+import secrets
+
+from fastapi import Depends, FastAPI, Header
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
 from .embedding_service import EmbeddingService
 
 
-app = FastAPI()
+def verify_api_key(authorization: str | None = Header(default=None)) -> None:
+    expected_key = os.environ.get("EMBEDDING_API_KEY")
+
+    if not expected_key:
+        raise HTTPException(
+            status_code=500,
+            detail="EMBEDDING_API_KEY is not configured",
+        )
+
+    scheme, _, token = (authorization or "").partition(" ")
+
+    if scheme != "Bearer" or not token or not secrets.compare_digest(token, expected_key):
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
+app = FastAPI(dependencies=[Depends(verify_api_key)])
 
 embedding_service = EmbeddingService()
 

--- a/src/embeddings/embedding_api.py
+++ b/src/embeddings/embedding_api.py
@@ -23,7 +23,12 @@ def verify_api_key(authorization: str | None = Header(default=None)) -> None:
         raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
 
-app = FastAPI(dependencies=[Depends(verify_api_key)])
+app = FastAPI(
+    dependencies=[Depends(verify_api_key)],
+    openapi_url=None,
+    docs_url=None,
+    redoc_url=None,
+)
 
 embedding_service = EmbeddingService()
 

--- a/src/embeddings/test_embedding_api_unit.py
+++ b/src/embeddings/test_embedding_api_unit.py
@@ -281,39 +281,60 @@ class TestEmbedBatchEndpoint:
         assert response.status_code == 200
 
 
+ENDPOINTS = [
+    ("/embed", {"text": "hello"}),
+    ("/embed-query", {"text": "hello"}),
+    ("/embed-batch", {"texts": ["hello"]}),
+]
+
+
 class TestAuthentication:
+    @pytest.mark.parametrize("path,payload", ENDPOINTS)
     def test_rejects_request_with_no_authorization_header(
-        self, api_module, fake_service
+        self, api_module, fake_service, path, payload
     ):
         unauthenticated_client = TestClient(api_module.app)
 
-        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+        response = unauthenticated_client.post(path, json=payload)
 
         assert response.status_code == 401
         assert fake_service.embed_document_calls == []
+        assert fake_service.embed_query_calls == []
+        assert fake_service.embed_batch_calls == []
 
-    def test_rejects_request_with_wrong_key(self, api_module, fake_service):
+    @pytest.mark.parametrize("path,payload", ENDPOINTS)
+    def test_rejects_request_with_wrong_key(
+        self, api_module, fake_service, path, payload
+    ):
         unauthenticated_client = TestClient(
             api_module.app, headers={"Authorization": "Bearer wrong-key"}
         )
 
-        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+        response = unauthenticated_client.post(path, json=payload)
 
         assert response.status_code == 401
         assert fake_service.embed_document_calls == []
+        assert fake_service.embed_query_calls == []
+        assert fake_service.embed_batch_calls == []
 
-    def test_rejects_request_with_non_bearer_scheme(self, api_module, fake_service):
+    @pytest.mark.parametrize("path,payload", ENDPOINTS)
+    def test_rejects_request_with_non_bearer_scheme(
+        self, api_module, fake_service, path, payload
+    ):
         unauthenticated_client = TestClient(
             api_module.app, headers={"Authorization": TEST_API_KEY}
         )
 
-        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+        response = unauthenticated_client.post(path, json=payload)
 
         assert response.status_code == 401
         assert fake_service.embed_document_calls == []
+        assert fake_service.embed_query_calls == []
+        assert fake_service.embed_batch_calls == []
 
+    @pytest.mark.parametrize("path,payload", ENDPOINTS)
     def test_fails_closed_when_api_key_is_not_configured(
-        self, api_module, fake_service, monkeypatch
+        self, api_module, fake_service, monkeypatch, path, payload
     ):
         monkeypatch.delenv("EMBEDDING_API_KEY", raising=False)
 
@@ -321,7 +342,26 @@ class TestAuthentication:
             api_module.app, headers={"Authorization": f"Bearer {TEST_API_KEY}"}
         )
 
-        response = unconfigured_client.post("/embed", json={"text": "hello"})
+        response = unconfigured_client.post(path, json=payload)
 
         assert response.status_code == 500
         assert fake_service.embed_document_calls == []
+        assert fake_service.embed_query_calls == []
+        assert fake_service.embed_batch_calls == []
+
+
+class TestDocsDisabled:
+    def test_openapi_json_is_disabled(self, client):
+        response = client.get("/openapi.json")
+
+        assert response.status_code == 404
+
+    def test_docs_ui_is_disabled(self, client):
+        response = client.get("/docs")
+
+        assert response.status_code == 404
+
+    def test_redoc_ui_is_disabled(self, client):
+        response = client.get("/redoc")
+
+        assert response.status_code == 404

--- a/src/embeddings/test_embedding_api_unit.py
+++ b/src/embeddings/test_embedding_api_unit.py
@@ -19,6 +19,8 @@ from fastapi.testclient import TestClient
 
 SRC_DIR = Path(__file__).resolve().parent.parent
 
+TEST_API_KEY = "test-embedding-key"
+
 
 class FakeEncodedVector:
     """Stand-in for the numpy array normally returned by
@@ -89,6 +91,8 @@ def api_module(monkeypatch):
     for name in ("embeddings.embedding_api", "embeddings.embedding_service"):
         monkeypatch.delitem(sys.modules, name, raising=False)
 
+    monkeypatch.setenv("EMBEDDING_API_KEY", TEST_API_KEY)
+
     module = importlib.import_module("embeddings.embedding_api")
 
     yield module
@@ -106,7 +110,9 @@ def fake_service(api_module, monkeypatch):
 
 @pytest.fixture
 def client(api_module, fake_service):
-    return TestClient(api_module.app)
+    return TestClient(
+        api_module.app, headers={"Authorization": f"Bearer {TEST_API_KEY}"}
+    )
 
 
 class TestEmbedEndpoint:
@@ -273,3 +279,49 @@ class TestEmbedBatchEndpoint:
         )
 
         assert response.status_code == 200
+
+
+class TestAuthentication:
+    def test_rejects_request_with_no_authorization_header(
+        self, api_module, fake_service
+    ):
+        unauthenticated_client = TestClient(api_module.app)
+
+        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+
+        assert response.status_code == 401
+        assert fake_service.embed_document_calls == []
+
+    def test_rejects_request_with_wrong_key(self, api_module, fake_service):
+        unauthenticated_client = TestClient(
+            api_module.app, headers={"Authorization": "Bearer wrong-key"}
+        )
+
+        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+
+        assert response.status_code == 401
+        assert fake_service.embed_document_calls == []
+
+    def test_rejects_request_with_non_bearer_scheme(self, api_module, fake_service):
+        unauthenticated_client = TestClient(
+            api_module.app, headers={"Authorization": TEST_API_KEY}
+        )
+
+        response = unauthenticated_client.post("/embed", json={"text": "hello"})
+
+        assert response.status_code == 401
+        assert fake_service.embed_document_calls == []
+
+    def test_fails_closed_when_api_key_is_not_configured(
+        self, api_module, fake_service, monkeypatch
+    ):
+        monkeypatch.delenv("EMBEDDING_API_KEY", raising=False)
+
+        unconfigured_client = TestClient(
+            api_module.app, headers={"Authorization": f"Bearer {TEST_API_KEY}"}
+        )
+
+        response = unconfigured_client.post("/embed", json={"text": "hello"})
+
+        assert response.status_code == 500
+        assert fake_service.embed_document_calls == []

--- a/tests/embedding-client.test.ts
+++ b/tests/embedding-client.test.ts
@@ -77,7 +77,10 @@ describe('embedText', () => {
       'http://127.0.0.1:8000/embed',
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-embedding-key',
+        },
         body: JSON.stringify({ text: 'hello world' }),
       }),
     );
@@ -272,6 +275,22 @@ describe('embedText', () => {
 
     expect(result.embedding).toEqual(TEST_EMBEDDING);
   });
+
+  it('throws without calling fetch when EMBEDDING_API_KEY is not configured', async () => {
+    delete process.env.EMBEDDING_API_KEY;
+
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(makeResponse());
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { embedText } = await loadEmbeddingClient();
+
+    await expect(embedText('hi')).rejects.toThrow(
+      'EMBEDDING_API_KEY is not configured',
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('embedQuery', () => {
@@ -300,7 +319,10 @@ describe('embedQuery', () => {
       'http://127.0.0.1:8000/embed-query',
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-embedding-key',
+        },
         body: JSON.stringify({ text: 'what treatments have I tried?' }),
       }),
     );
@@ -340,5 +362,21 @@ describe('embedQuery', () => {
     await expect(embedQuery('hi')).rejects.toThrow(
       'Embedding API request failed: 500 Internal Server Error',
     );
+  });
+
+  it('throws without calling fetch when EMBEDDING_API_KEY is not configured', async () => {
+    delete process.env.EMBEDDING_API_KEY;
+
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(makeResponse());
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { embedQuery } = await loadEmbeddingClient();
+
+    await expect(embedQuery('hi')).rejects.toThrow(
+      'EMBEDDING_API_KEY is not configured',
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/embedding-client.test.ts
+++ b/tests/embedding-client.test.ts
@@ -53,6 +53,7 @@ describe('embedText', () => {
 
   it('sends a POST request to the default embedding API URL with the expected payload', async () => {
     delete process.env.EMBEDDING_API_URL;
+    process.env.EMBEDDING_API_KEY = 'test-embedding-key';
 
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
       makeResponse({
@@ -306,6 +307,7 @@ describe('embedQuery', () => {
 
   it('sends a POST request to /embed-query, not /embed', async () => {
     delete process.env.EMBEDDING_API_URL;
+    process.env.EMBEDDING_API_KEY = 'test-embedding-key';
 
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(makeResponse());
 


### PR DESCRIPTION
## Summary
- Add a shared API key requirement on the embedding service and disable its docs/openapi routes
- Add per-tool and vector-level authorization for user data isolation
- Expand `CONDITION_KEYWORDS` to close safety-pattern bypasses
- Decide streaming vs. full-response for the LLM call: stay full-response/buffered for now

Fixes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API-key authentication for embedding service requests using Bearer tokens.
  - Requests with missing or invalid credentials are rejected.
  - Embedding service documentation endpoints are no longer publicly available.
  - The embedding client now reports a clear error when its API key is not configured.

- **Documentation**
  - Updated setup instructions and environment configuration guidance for the embedding service.
  - Clarified that responses remain buffered rather than streamed.

- **Tests**
  - Added coverage for authentication failures, missing configuration, request headers, and disabled documentation endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->