### PR TITLE
chore: add npm audit CI gate, Dependabot config, fix high-severity deepmerge-ts CVE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/src/embeddings"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/evaluation/embeddings"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+
       - name: Prepare test environment
         run: |
           echo "DATABASE_URL=$DATABASE_URL" > .env.test

--- a/package-lock.json
+++ b/package-lock.json
@@ -3747,13 +3747,23 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+      "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
       "devOptional": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/defu": {

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "js-tiktoken": "^1.0.21",
     "jsonwebtoken": "^9.0.3",
     "zod": "^4.4.3"
+  },
+  "overrides": {
+    "deepmerge-ts": "^8.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- Add `npm audit --audit-level=high` step to CI, and `.github/dependabot.yml` (npm root + both Python requirement dirs: `src/embeddings`, `evaluation/embeddings`).
- The audit step surfaced a real high-severity finding: `deepmerge-ts <8.0.0` (GHSA-ggr8-5vv4-36mx, stack exhaustion), pulled in transitively via `prisma`/`@prisma/config`, with no upstream Prisma release yet that bumps past it.
- Fixed with a targeted `overrides` entry (`deepmerge-ts: ^8.0.2`) — the only consumer in the tree, verified compatible against `prisma validate`, `prisma db push`, and the full test suite.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (241/241 passing)
- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] `prisma validate` / `prisma db push` against forced `deepmerge-ts@8.0.2`
- [x] `.github/dependabot.yml` validated as well-formed YAML

Fixes #98
Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)