### PR TITLE
refactor: dedupe safety-refusal response shape and assert routeIntent call

### DIFF
--- a/src/ai-agent/ai-agent-orchestrator.ts
+++ b/src/ai-agent/ai-agent-orchestrator.ts
@@ -11,6 +11,17 @@ import {
   DIAGNOSIS_REQUEST_MESSAGE,
 } from '../safety/safety-service.js';
 
+function safetyRefusalResponse(message: string) {
+  return {
+    answer: message,
+    citations: [],
+    intent: 'safety' as const,
+    metadata: {
+      retrievedChunks: [],
+    },
+  };
+}
+
 export async function runAgent(
   question: string,
   userId: number,
@@ -26,14 +37,7 @@ export async function runAgent(
   state.safety = safety;
 
   if (!safety.allowed) {
-    return {
-      answer: safety.message,
-      citations: [],
-      intent: 'safety' as const,
-      metadata: {
-        retrievedChunks: [],
-      },
-    };
+    return safetyRefusalResponse(safety.message);
   }
 
   const intent = routeIntent(question, requestId);
@@ -42,14 +46,7 @@ export async function runAgent(
 
   switch (intent) {
     case 'safety':
-      return {
-        answer: DIAGNOSIS_REQUEST_MESSAGE,
-        citations: [],
-        intent,
-        metadata: {
-          retrievedChunks: [],
-        },
-      };
+      return safetyRefusalResponse(DIAGNOSIS_REQUEST_MESSAGE);
 
     case 'journal': {
       state.toolUsed = 'journal-tool';

--- a/tests/ai-agent-orchestrator.test.ts
+++ b/tests/ai-agent-orchestrator.test.ts
@@ -67,6 +67,10 @@ describe('agent orchestrator', () => {
 
     const result = await runAgent('What condition might this be?', 1);
 
+    expect(routeIntentMock).toHaveBeenCalledWith(
+      'What condition might this be?',
+      undefined,
+    );
     expect(ragToolMock).not.toHaveBeenCalled();
     expect(journalToolMock).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## Summary
- Extracts `safetyRefusalResponse()` helper to remove duplication between the `!safety.allowed` early return and the `case 'safety':` branch.
- Adds missing `routeIntentMock` call assertion to the diagnosis-refusal orchestrator test.

Fixes #151