### PR TITLE
feat: distinguish 500 error causes with specific error codes

### DIFF
--- a/docs/05-api-contract.md
+++ b/docs/05-api-contract.md
@@ -75,7 +75,8 @@ missing-switch-case defect.
 
 **Errors**
 
-Every error body now includes a machine-readable `code` field alongside `error` (issue #123):
+Every error body includes a machine-readable `code` field alongside `error` (issue #123).
+500s further distinguish the failing dependency where the thrown error type allows it (issue #172):
 
 | Status | Body | Trigger |
 |--------|------|---------|
@@ -85,7 +86,10 @@ Every error body now includes a machine-readable `code` field alongside `error` 
 | 400 | `{ "error": "Question exceeds maximum length of 10000 characters", "code": "question_too_long" }` | `question` longer than the 10,000-character limit |
 | 400 | `{ "error": "Invalid injuryId", "code": "invalid_injury_id" }` | `injuryId` present but fails the check above |
 | 429 | `{ "error": "Too many requests, please try again later.", "code": "rate_limited" }` | more than 20 requests from the same IP within a 60s window (issue #89) |
-| 500 | `{ "error": "Failed to process request", "code": "internal_error" }` | catch-all — embedding service down, DB error, LLM call failure/invalid key, missing `JWT_SECRET`. All still collapse to the single `internal_error` code; it distinguishes 500s from other failure classes but not from each other. |
+| 500 | `{ "error": "Failed to process request", "code": "embedding_service_error" }` | the embedding service call (`src/embeddings/embedding-client.ts`) failed — missing `EMBEDDING_API_KEY`, network/connection failure, non-OK HTTP response, or an invalid/malformed response shape |
+| 500 | `{ "error": "Failed to process request", "code": "database_error" }` | Prisma threw `PrismaClientKnownRequestError` or `PrismaClientInitializationError` (query failure or DB unreachable) |
+| 500 | `{ "error": "Failed to process request", "code": "llm_service_error" }` | the Groq LLM call threw a `Groq.APIError` (or subclass — rate limit, auth, connection, etc.) |
+| 500 | `{ "error": "Failed to process request", "code": "internal_error" }` | fallback for any other unexpected exception, including a missing `JWT_SECRET` in `authenticate.ts` |
 
 `askAgent` destructures `req.body ?? {}`, so a body-less `POST /ai-agent` returns the 400 above
 rather than a 500 (fixed as issue #61).
@@ -121,11 +125,11 @@ limit of `5` for the `rag` intent path.
   `citation-formatter.ts` are not called from any response path. `citation-source-mapper.ts` is
   also unwired, and even if it were, it only maps 2 of the 5 valid `sourceType` values
   (`treatment`, `medical_visit` — missing `symptom`, `timeline_event`, `injury`).
-- **All 4xx/429 failure modes have a distinct `code` (issue #123), but 500s do not.** A client can
-  now tell "authentication required" from "rate limited" from "question too long" apart, but every
-  500 still reports `code: "internal_error"` regardless of whether the cause was the embedding
-  service being unreachable, a database error, or an LLM call failure — 500 causes are not
-  distinguishable from the response alone.
+- **500 responses distinguish the failing dependency where the thrown error type allows it (issue
+  #172)**, but not further than that: `embedding_service_error` covers every embedding-client
+  failure (missing key, network failure, non-OK response, invalid shape) without distinguishing
+  those from each other, and any exception the controller doesn't recognize (e.g. a missing
+  `JWT_SECRET`) still falls back to the generic `internal_error`.
 
 ## 6. What the frontend will need that the backend doesn't provide yet
 
@@ -145,9 +149,10 @@ This is the most important section — these are gaps, not just documentation de
   no create/update/delete for any of these at all.
 - **Pagination or a client-settable retrieval limit.** The `rag` intent path hardcodes `5`
   internally with no way for the frontend to request more, or to page through additional chunks.
-- **Structured error information for 500s specifically.** Issue #123 added a `code` field
-  distinguishing every 4xx/429 case (see §3), but all 500s still share one `internal_error` code —
-  a UI still can't tell "service temporarily unavailable" apart from other internal failures.
+- **Finer-grained 500 codes than the three dependency buckets.** Issue #172 split 500s into
+  `embedding_service_error` / `database_error` / `llm_service_error` / `internal_error` (see §3),
+  but a UI still can't tell e.g. "embedding service unreachable" apart from "embedding service
+  returned a malformed response" — both share `embedding_service_error`.
 - **Conversation/thread state.** Every call is fully stateless — no way to support a multi-turn
   conversation UI without the frontend re-sending full context itself (and there's currently no
   mechanism to do even that).

--- a/src/ai-agent/ai-agent-controller.ts
+++ b/src/ai-agent/ai-agent-controller.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from 'node:crypto';
 import { Request, Response } from 'express';
 import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import Groq from 'groq-sdk';
 import { runAgent } from './ai-agent-orchestrator.js';
 import { logError } from '../lib/log-error.js';
 import { sendError } from '../lib/api-error.js';
+import { EmbeddingServiceError } from '../embeddings/embedding-client.js';
 
 // Mirrors EmbeddingRequest.text's own Field(max_length=10_000) in
 // src/embeddings/embedding_api.py -- the question is what gets embedded.
@@ -70,6 +73,21 @@ export async function askAgent(req: Request, res: Response) {
     return res.json(result);
   } catch (error) {
     logError('ai-agent request failed', error);
+
+    if (error instanceof EmbeddingServiceError) {
+      return sendError(res, 500, 'embedding_service_error', 'Failed to process request');
+    }
+
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError
+    ) {
+      return sendError(res, 500, 'database_error', 'Failed to process request');
+    }
+
+    if (error instanceof Groq.APIError) {
+      return sendError(res, 500, 'llm_service_error', 'Failed to process request');
+    }
 
     return sendError(res, 500, 'internal_error', 'Failed to process request');
   }

--- a/src/embeddings/embedding-client.ts
+++ b/src/embeddings/embedding-client.ts
@@ -1,3 +1,10 @@
+export class EmbeddingServiceError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'EmbeddingServiceError';
+  }
+}
+
 const EMBEDDING_API_URL =
   process.env.EMBEDDING_API_URL ?? 'http://127.0.0.1:8000';
 
@@ -20,7 +27,7 @@ type EmbeddingResponse = {
 
 function validateEmbeddingResponse(data: unknown): EmbeddingResponse {
   if (typeof data !== 'object' || data === null) {
-    throw new Error('Embedding API returned an invalid response');
+    throw new EmbeddingServiceError('Embedding API returned an invalid response');
   }
 
   const response = data as Record<string, unknown>;
@@ -32,7 +39,7 @@ function validateEmbeddingResponse(data: unknown): EmbeddingResponse {
     typeof response.dimension !== 'number' ||
     !Array.isArray(response.embedding)
   ) {
-    throw new Error('Embedding API returned an invalid response');
+    throw new EmbeddingServiceError('Embedding API returned an invalid response');
   }
 
   if (
@@ -42,7 +49,7 @@ function validateEmbeddingResponse(data: unknown): EmbeddingResponse {
       (value) => typeof value === 'number' && Number.isFinite(value),
     )
   ) {
-    throw new Error('Embedding API returned an invalid embedding');
+    throw new EmbeddingServiceError('Embedding API returned an invalid embedding');
   }
 
   return {
@@ -68,7 +75,7 @@ async function postEmbedding(
   const apiKey = process.env.EMBEDDING_API_KEY;
 
   if (!apiKey) {
-    throw new Error('EMBEDDING_API_KEY is not configured');
+    throw new EmbeddingServiceError('EMBEDDING_API_KEY is not configured');
   }
 
   const controller = new AbortController();
@@ -79,23 +86,42 @@ async function postEmbedding(
   );
 
   try {
-    const response = await fetch(`${EMBEDDING_API_URL}${path}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({ text }),
-      signal: controller.signal,
-    });
+    let response: Response;
+
+    try {
+      response = await fetch(`${EMBEDDING_API_URL}${path}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ text }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      throw new EmbeddingServiceError(message, { cause: error });
+    }
 
     if (!response.ok) {
-      throw new Error(
+      throw new EmbeddingServiceError(
         `Embedding API request failed: ${response.status} ${response.statusText}`,
       );
     }
 
-    const data = await response.json();
+    let data: unknown;
+
+    try {
+      data = await response.json();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      throw new EmbeddingServiceError(
+        `Embedding API returned a malformed response: ${message}`,
+        { cause: error },
+      );
+    }
 
     return validateEmbeddingResponse(data);
   } finally {

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -7,6 +7,9 @@ export type ApiErrorCode =
   | 'question_too_long'
   | 'invalid_injury_id'
   | 'rate_limited'
+  | 'embedding_service_error'
+  | 'database_error'
+  | 'llm_service_error'
   | 'internal_error';
 
 export function sendError(

--- a/tests/ai-agent-controller.test.ts
+++ b/tests/ai-agent-controller.test.ts
@@ -1,4 +1,6 @@
 import { jest } from '@jest/globals';
+import { Prisma } from '@prisma/client';
+import Groq from 'groq-sdk';
 
 const runAgentMock = jest.fn();
 
@@ -7,6 +9,9 @@ jest.unstable_mockModule('../src/ai-agent/ai-agent-orchestrator.js', () => ({
 }));
 
 const { askAgent } = await import('../src/ai-agent/ai-agent-controller.js');
+const { EmbeddingServiceError } = await import(
+  '../src/embeddings/embedding-client.js'
+);
 
 type MockRequest = {
   headers?: Record<string, string>;
@@ -298,7 +303,7 @@ describe('ai agent controller', () => {
     expect(res.status).toHaveBeenCalledWith(400);
   });
 
-  it('returns 500 when agent fails', async () => {
+  it('returns 500 with internal_error when agent fails with an unrecognized error', async () => {
     const req: MockRequest = {
       userId: 1,
       body: {
@@ -317,6 +322,101 @@ describe('ai agent controller', () => {
     expect(res.json).toHaveBeenCalledWith({
       error: 'Failed to process request',
       code: 'internal_error',
+    });
+  });
+
+  it('returns 500 with embedding_service_error when the embedding service fails', async () => {
+    const req: MockRequest = {
+      userId: 1,
+      body: {
+        question: 'test',
+      },
+    };
+
+    const res = mockResponse();
+
+    runAgentMock.mockRejectedValue(
+      new EmbeddingServiceError('Embedding API request failed: 503 Service Unavailable'),
+    );
+
+    await askAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Failed to process request',
+      code: 'embedding_service_error',
+    });
+  });
+
+  it('returns 500 with database_error when Prisma throws a known request error', async () => {
+    const req: MockRequest = {
+      userId: 1,
+      body: {
+        question: 'test',
+      },
+    };
+
+    const res = mockResponse();
+
+    runAgentMock.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: '6.0.0',
+      }),
+    );
+
+    await askAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Failed to process request',
+      code: 'database_error',
+    });
+  });
+
+  it('returns 500 with database_error when Prisma fails to initialize', async () => {
+    const req: MockRequest = {
+      userId: 1,
+      body: {
+        question: 'test',
+      },
+    };
+
+    const res = mockResponse();
+
+    runAgentMock.mockRejectedValue(
+      new Prisma.PrismaClientInitializationError('Cannot reach database server', '6.0.0'),
+    );
+
+    await askAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Failed to process request',
+      code: 'database_error',
+    });
+  });
+
+  it('returns 500 with llm_service_error when the Groq call fails', async () => {
+    const req: MockRequest = {
+      userId: 1,
+      body: {
+        question: 'test',
+      },
+    };
+
+    const res = mockResponse();
+
+    runAgentMock.mockRejectedValue(
+      new Groq.APIError(429, undefined, 'Rate limit exceeded', undefined),
+    );
+
+    await askAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Failed to process request',
+      code: 'llm_service_error',
     });
   });
 });

--- a/tests/embedding-client.test.ts
+++ b/tests/embedding-client.test.ts
@@ -124,7 +124,7 @@ describe('embedText', () => {
     expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it('throws a descriptive error when the response is not ok', async () => {
+  it('throws a descriptive EmbeddingServiceError when the response is not ok', async () => {
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
       makeResponse({
         ok: false,
@@ -135,23 +135,58 @@ describe('embedText', () => {
 
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const { embedText } = await loadEmbeddingClient();
+    const { embedText, EmbeddingServiceError } = await loadEmbeddingClient();
 
     await expect(embedText('hi')).rejects.toThrow(
       'Embedding API request failed: 500 Internal Server Error',
     );
+    await expect(embedText('hi')).rejects.toBeInstanceOf(EmbeddingServiceError);
   });
 
-  it('propagates network errors thrown by fetch', async () => {
+  it('wraps network errors thrown by fetch in an EmbeddingServiceError', async () => {
     const fetchMock = jest
       .fn<typeof fetch>()
       .mockRejectedValue(new Error('network down'));
 
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const { embedText } = await loadEmbeddingClient();
+    const { embedText, EmbeddingServiceError } = await loadEmbeddingClient();
 
     await expect(embedText('hi')).rejects.toThrow('network down');
+    await expect(embedText('hi')).rejects.toBeInstanceOf(EmbeddingServiceError);
+  });
+
+  it('wraps a malformed (non-JSON) response body in an EmbeddingServiceError', async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
+      makeResponse({
+        json: async () => {
+          throw new SyntaxError('Unexpected token < in JSON at position 0');
+        },
+      }),
+    );
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { embedText, EmbeddingServiceError } = await loadEmbeddingClient();
+
+    await expect(embedText('hi')).rejects.toThrow(
+      'Embedding API returned a malformed response',
+    );
+    await expect(embedText('hi')).rejects.toBeInstanceOf(EmbeddingServiceError);
+  });
+
+  it('sets EmbeddingServiceError.name so logs identify the error class', async () => {
+    delete process.env.EMBEDDING_API_KEY;
+
+    const { embedText, EmbeddingServiceError } = await loadEmbeddingClient();
+
+    try {
+      await embedText('hi');
+      throw new Error('expected embedText to reject');
+    } catch (error) {
+      expect(error).toBeInstanceOf(EmbeddingServiceError);
+      expect((error as Error).name).toBe('EmbeddingServiceError');
+    }
   });
 
   it('clears the timeout after a successful request', async () => {
@@ -277,18 +312,19 @@ describe('embedText', () => {
     expect(result.embedding).toEqual(TEST_EMBEDDING);
   });
 
-  it('throws without calling fetch when EMBEDDING_API_KEY is not configured', async () => {
+  it('throws an EmbeddingServiceError without calling fetch when EMBEDDING_API_KEY is not configured', async () => {
     delete process.env.EMBEDDING_API_KEY;
 
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(makeResponse());
 
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const { embedText } = await loadEmbeddingClient();
+    const { embedText, EmbeddingServiceError } = await loadEmbeddingClient();
 
     await expect(embedText('hi')).rejects.toThrow(
       'EMBEDDING_API_KEY is not configured',
     );
+    await expect(embedText('hi')).rejects.toBeInstanceOf(EmbeddingServiceError);
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -348,7 +384,7 @@ describe('embedQuery', () => {
     );
   });
 
-  it('throws a descriptive error when the response is not ok', async () => {
+  it('throws a descriptive EmbeddingServiceError when the response is not ok', async () => {
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
       makeResponse({
         ok: false,
@@ -359,25 +395,27 @@ describe('embedQuery', () => {
 
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const { embedQuery } = await loadEmbeddingClient();
+    const { embedQuery, EmbeddingServiceError } = await loadEmbeddingClient();
 
     await expect(embedQuery('hi')).rejects.toThrow(
       'Embedding API request failed: 500 Internal Server Error',
     );
+    await expect(embedQuery('hi')).rejects.toBeInstanceOf(EmbeddingServiceError);
   });
 
-  it('throws without calling fetch when EMBEDDING_API_KEY is not configured', async () => {
+  it('throws an EmbeddingServiceError without calling fetch when EMBEDDING_API_KEY is not configured', async () => {
     delete process.env.EMBEDDING_API_KEY;
 
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(makeResponse());
 
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const { embedQuery } = await loadEmbeddingClient();
+    const { embedQuery, EmbeddingServiceError } = await loadEmbeddingClient();
 
     await expect(embedQuery('hi')).rejects.toThrow(
       'EMBEDDING_API_KEY is not configured',
     );
+    await expect(embedQuery('hi')).rejects.toBeInstanceOf(EmbeddingServiceError);
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/tests/integration/ai-agent-route.integration.test.ts
+++ b/tests/integration/ai-agent-route.integration.test.ts
@@ -7,6 +7,7 @@ import { signTestToken } from '../helpers/auth.js';
 
 jest.unstable_mockModule('../../src/embeddings/embedding-client.js', () => ({
   embedQuery: jest.fn(),
+  EmbeddingServiceError: class EmbeddingServiceError extends Error {},
 }));
 
 jest.unstable_mockModule('../../src/llm/llm-client.js', () => ({

--- a/tests/integration/data-isolation.integration.test.ts
+++ b/tests/integration/data-isolation.integration.test.ts
@@ -12,6 +12,7 @@ import { signTestToken } from '../helpers/auth.js';
 
 jest.unstable_mockModule('../../src/embeddings/embedding-client.js', () => ({
   embedQuery: jest.fn(),
+  EmbeddingServiceError: class EmbeddingServiceError extends Error {},
 }));
 
 jest.unstable_mockModule('../../src/llm/llm-client.js', () => ({


### PR DESCRIPTION
## Summary
- Splits the `ai-agent-controller` catch-all 500 into `embedding_service_error`, `database_error`, and `llm_service_error` codes, classified via `instanceof` against a new `EmbeddingServiceError`, Prisma's known-request/initialization errors, and `Groq.APIError` — falling back to `internal_error` otherwise.
- `embedding-client.ts` now also wraps network failures and malformed (non-JSON) response bodies in `EmbeddingServiceError`, so those causes get classified too instead of falling through to `internal_error`.
- Updated `docs/05-api-contract.md` to document the four distinct 500 codes.

Fixes #172

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (247/247 passing, including integration suite)
- [x] `npm run build`
- [x] `/self-review` run twice (once before, once after addressing findings)
- [x] `/security-review` run — no HIGH/MEDIUM findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)