### PR TITLE
feat: add minimal static frontend for POST /ai-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,23 @@ curl -X POST http://localhost:3000/ai-agent \
 `sub` claim, signed with `JWT_SECRET`) — see the Project Status section above for what
 authentication does and doesn't cover yet.
 
+### Minimal frontend
+
+A static demo page is served at `http://localhost:3000/` (`public/index.html` +
+`public/app.js`, no build step) once the backend is running. It has a field for the question, an
+optional injury ID, and a bearer token — this repo verifies but does not issue JWTs (a separate
+journal application is expected to own login, see `docs/02-architecture.md` D10), so for local
+testing you need to mint your own token with `JWT_SECRET`:
+
+```bash
+JWT_SECRET=<same value as .env> npx tsx -e "
+import jwt from 'jsonwebtoken';
+console.log(jwt.sign({ sub: '1' }, process.env.JWT_SECRET, { algorithm: 'HS256', expiresIn: '1h' }));
+"
+```
+
+Paste the printed token into the page's token field.
+
 ## Tests
 
 ```bash

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,97 @@
+const tokenInput = document.getElementById('token');
+const questionInput = document.getElementById('question');
+const injuryIdInput = document.getElementById('injuryId');
+const submitButton = document.getElementById('submit');
+const statusEl = document.getElementById('status');
+const errorEl = document.getElementById('error');
+const resultEl = document.getElementById('result');
+const answerEl = document.getElementById('answer');
+const citationsEl = document.getElementById('citations');
+
+function setHidden(el, hidden) {
+  el.hidden = hidden;
+}
+
+function formatCitation(citation) {
+  const parts = [citation.label, citation.sourceType, `#${citation.sourceId}`];
+
+  if (citation.date) {
+    parts.push(citation.date);
+  }
+
+  return parts.filter(Boolean).join(' — ');
+}
+
+function renderCitations(citations) {
+  citationsEl.innerHTML = '';
+
+  for (const citation of citations ?? []) {
+    const item = document.createElement('li');
+    item.textContent = formatCitation(citation);
+    citationsEl.appendChild(item);
+  }
+}
+
+async function submitQuestion() {
+  const token = tokenInput.value.trim();
+  const question = questionInput.value.trim();
+  const injuryIdRaw = injuryIdInput.value.trim();
+
+  setHidden(errorEl, true);
+  setHidden(resultEl, true);
+  errorEl.textContent = '';
+
+  if (!token) {
+    errorEl.textContent = 'A bearer token is required.';
+    setHidden(errorEl, false);
+    return;
+  }
+
+  if (!question) {
+    errorEl.textContent = 'A question is required.';
+    setHidden(errorEl, false);
+    return;
+  }
+
+  const body = { question };
+
+  if (injuryIdRaw) {
+    body.injuryId = Number(injuryIdRaw);
+  }
+
+  submitButton.disabled = true;
+  statusEl.textContent = 'Asking...';
+  setHidden(statusEl, false);
+
+  try {
+    const response = await fetch('/ai-agent', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      const code = data.code ? ` (${data.code})` : '';
+      errorEl.textContent = `${data.error ?? 'Request failed'}${code}`;
+      setHidden(errorEl, false);
+      return;
+    }
+
+    answerEl.textContent = data.answer;
+    renderCitations(data.citations);
+    setHidden(resultEl, false);
+  } catch {
+    errorEl.textContent = 'Network error — is the server reachable?';
+    setHidden(errorEl, false);
+  } finally {
+    submitButton.disabled = false;
+    setHidden(statusEl, true);
+  }
+}
+
+submitButton.addEventListener('click', submitQuestion);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Injury Journal AI</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 640px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1a1a1a;
+      }
+      label {
+        display: block;
+        margin-top: 1rem;
+        font-weight: 600;
+      }
+      input,
+      textarea {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 0.5rem;
+        margin-top: 0.25rem;
+        font: inherit;
+      }
+      textarea {
+        min-height: 5rem;
+        resize: vertical;
+      }
+      button {
+        margin-top: 1rem;
+        padding: 0.6rem 1.2rem;
+        font: inherit;
+        cursor: pointer;
+      }
+      button:disabled {
+        cursor: default;
+        opacity: 0.6;
+      }
+      #status {
+        margin-top: 1rem;
+        font-style: italic;
+        color: #555;
+      }
+      #error {
+        margin-top: 1rem;
+        color: #b00020;
+        white-space: pre-wrap;
+      }
+      #result {
+        margin-top: 1.5rem;
+      }
+      #answer {
+        white-space: pre-wrap;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        padding: 1rem;
+      }
+      #citations {
+        margin-top: 0.75rem;
+        padding-left: 1.25rem;
+        font-size: 0.9rem;
+        color: #333;
+      }
+      .help {
+        font-weight: normal;
+        font-size: 0.85rem;
+        color: #666;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Injury Journal AI</h1>
+
+    <label for="token"
+      >Bearer token
+      <span class="help"
+        >This service verifies but does not issue tokens (see README) — paste one signed with the
+        server's <code>JWT_SECRET</code>.</span
+      ></label
+    >
+    <input id="token" type="text" autocomplete="off" placeholder="eyJhbGciOi..." />
+
+    <label for="question">Question</label>
+    <textarea id="question" maxlength="10000" placeholder="What treatments have I tried?"></textarea>
+
+    <label for="injuryId">Injury ID <span class="help">(optional)</span></label>
+    <input id="injuryId" type="number" min="1" step="1" />
+
+    <button id="submit">Ask</button>
+
+    <div id="status" hidden></div>
+    <div id="error" hidden></div>
+
+    <div id="result" hidden>
+      <div id="answer"></div>
+      <ul id="citations"></ul>
+    </div>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,8 @@ app.use(cors({ origin: allowedOrigins ?? true }));
 
 app.use(express.json());
 
+app.use(express.static('public'));
+
 const aiAgentLimiter = rateLimit({
   windowMs: 60_000,
   limit: 20,

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -48,6 +48,20 @@ describe('GET / static frontend', () => {
       await prisma.$disconnect();
     }
   });
+
+  it('serves the static app.js bundle', async () => {
+    const { app, prisma } = await loadApp();
+
+    try {
+      const response = await request(app).get('/app.js');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/javascript/);
+      expect(response.text).toContain('submitQuestion');
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
 });
 
 describe('POST /ai-agent rate limiting', () => {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -34,6 +34,22 @@ async function loadApp() {
   return { app, prisma };
 }
 
+describe('GET / static frontend', () => {
+  it('serves the static index page', async () => {
+    const { app, prisma } = await loadApp();
+
+    try {
+      const response = await request(app).get('/');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/text\/html/);
+      expect(response.text).toContain('Injury Journal AI');
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+});
+
 describe('POST /ai-agent rate limiting', () => {
   it('does not crash when a reverse proxy sends X-Forwarded-For', async () => {
     // Regression test: express-rate-limit throws if a proxy header is


### PR DESCRIPTION
## Summary

- Adds `public/index.html` + `public/app.js` — a static, no-build-step page (bearer token field, question, optional injury ID) that calls `POST /ai-agent` and renders the answer/citations, per issue #176.
- `src/app.ts` now serves `public/` via `express.static`, same-origin so no CORS changes are needed and helmet's default CSP is untouched (script is external, not inline).
- README documents the page and how to mint a local dev JWT for testing, since this repo verifies but does not issue tokens (D10 — the separate journal app owns login).

No API contract changes, no auth/token-issuer added (explicitly out of scope per #176 and D10).

Fixes #176

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — 253/254 passing; the one failure (`authenticate.test.ts`, stale assertion missing the `code` field) is pre-existing on `main`, unrelated to this change, and already tracked as #182
- [x] Manual: ran the dev server against the real test DB/Groq creds, confirmed `GET /` serves the page and a full `POST /ai-agent` round trip works through the same flow the UI uses