### PR TITLE
fix: update stale authenticate.test.ts assertion to include code field

### DIFF
--- a/tests/authenticate.test.ts
+++ b/tests/authenticate.test.ts
@@ -156,7 +156,10 @@ describe('authenticate middleware', () => {
     authenticate(req as never, res as never, next as never);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Authentication required',
+      code: 'authentication_required',
+    });
     expect(next).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- The "rejects a header with trailing content after the token" test in `tests/authenticate.test.ts` asserted `{ error: 'Authentication required' }`, but the `authenticate` middleware has included a `code` field in its error response since #123.
- Updates the assertion to `{ error: 'Authentication required', code: 'authentication_required' }`, matching every sibling test in the same file.

Fixes #182

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 257/257 passing