### PR TITLE
test: add rate-limit coverage for GET /injuries

### DIFF
--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -175,6 +175,92 @@ describe('POST /ai-agent rate limiting', () => {
   });
 });
 
+describe('GET /injuries rate limiting', () => {
+  it('allows a user up to their configured limit, then returns 429 with a JSON error body', async () => {
+    const { app, prisma } = await loadApp();
+
+    try {
+      // Vary X-Forwarded-For per request so the shared, lower-limit (40/min)
+      // ipLimiter never trips first -- this test targets injuriesUserLimiter
+      // (60/min, keyed by userId) specifically.
+      for (let i = 0; i < 60; i++) {
+        const response = await request(app)
+          .get('/injuries')
+          .set('X-Forwarded-For', `10.0.0.${i}`)
+          .set('Authorization', authHeader);
+
+        expect(response.status).toBe(200);
+      }
+
+      const limitedResponse = await request(app)
+        .get('/injuries')
+        .set('X-Forwarded-For', '10.0.0.60')
+        .set('Authorization', authHeader);
+
+      expect(limitedResponse.status).toBe(429);
+      expect(limitedResponse.headers['content-type']).toMatch(
+        /application\/json/,
+      );
+      expect(limitedResponse.body).toEqual({
+        error: 'Too many requests, please try again later.',
+        code: 'rate_limited',
+      });
+    } finally {
+      await prisma.$disconnect();
+    }
+  }, 20_000);
+
+  it('does not let exhausting /ai-agent rate-limit /injuries for the same user', async () => {
+    const { app, prisma } = await loadApp();
+
+    try {
+      for (let i = 0; i < 20; i++) {
+        const response = await request(app)
+          .post('/ai-agent')
+          .set('Authorization', authHeader)
+          .send({ question: SAFETY_BLOCKED_QUESTION });
+
+        expect(response.status).toBe(200);
+      }
+
+      const injuriesResponse = await request(app)
+        .get('/injuries')
+        .set('Authorization', authHeader);
+
+      expect(injuriesResponse.status).toBe(200);
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  it('does not let exhausting /injuries rate-limit /ai-agent for the same user', async () => {
+    const { app, prisma } = await loadApp();
+
+    try {
+      // Vary X-Forwarded-For per request so the shared ipLimiter (40/min)
+      // doesn't trip before injuriesUserLimiter's 60/min budget is exhausted.
+      for (let i = 0; i < 60; i++) {
+        const response = await request(app)
+          .get('/injuries')
+          .set('X-Forwarded-For', `10.0.0.${i}`)
+          .set('Authorization', authHeader);
+
+        expect(response.status).toBe(200);
+      }
+
+      const aiAgentResponse = await request(app)
+        .post('/ai-agent')
+        .set('X-Forwarded-For', '10.0.0.60')
+        .set('Authorization', authHeader)
+        .send({ question: SAFETY_BLOCKED_QUESTION });
+
+      expect(aiAgentResponse.status).toBe(200);
+    } finally {
+      await prisma.$disconnect();
+    }
+  }, 20_000);
+});
+
 describe('GET /injuries', () => {
   // Only the unauthenticated case is asserted here: it proves the route is
   // mounted behind `authenticate` without needing a database. The listing


### PR DESCRIPTION
## Summary
- `GET /injuries` had only a mount check; its dedicated `injuriesUserLimiter`
  (src/app.ts) was untested, so a regression that dropped it -- or swapped in
  the shared `/ai-agent` user limiter -- would pass CI silently.
- Adds a test asserting the 429 behavior at the configured limit (60/min).
- Adds two tests asserting the limiters' independence: exhausting one route's
  user budget must not rate-limit the other for the same user. That's the
  property a refactor is most likely to break, and the one this issue exists
  to protect.

Verified the new tests actually catch the regression by temporarily swapping
`injuriesUserLimiter` for `userLimiter` on the `/injuries` mount (the issue's
repro) and confirming all three fail, then reverting.

Fixes #197