### PR TITLE
fix: hard-split oversized words in the document chunker

### DIFF
--- a/src/ingestion/chunking/document-chunker.ts
+++ b/src/ingestion/chunking/document-chunker.ts
@@ -89,7 +89,7 @@ export function chunkDocument(
   document: JournalDocument,
   maxTokens: number = DEFAULT_MAX_TOKENS,
 ): JournalDocument[] {
-  if (maxTokens < 1) {
+  if (!(maxTokens >= 1)) {
     throw new Error(`maxTokens must be at least 1, received ${maxTokens}`);
   }
 

--- a/src/ingestion/chunking/document-chunker.ts
+++ b/src/ingestion/chunking/document-chunker.ts
@@ -23,12 +23,30 @@ function splitIntoSentences(text: string): string[] {
   );
 }
 
+// Splits on Unicode code-point boundaries and measures each candidate with
+// countTokens, rather than slicing raw BPE token ids: cl100k_base tokens are
+// byte sequences, not character-aligned, so decoding an arbitrary token slice
+// can land mid-character and silently emit replacement characters.
 function splitOversizedWord(word: string, maxTokens: number): string[] {
-  const tokens = encoding.encode(word);
+  const chars = Array.from(word);
   const pieces: string[] = [];
+  let start = 0;
 
-  for (let i = 0; i < tokens.length; i += maxTokens) {
-    pieces.push(encoding.decode(tokens.slice(i, i + maxTokens)));
+  while (start < chars.length) {
+    let lo = start + 1;
+    let hi = chars.length;
+
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (countTokens(chars.slice(start, mid).join('')) <= maxTokens) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+
+    pieces.push(chars.slice(start, lo).join(''));
+    start = lo;
   }
 
   return pieces;

--- a/src/ingestion/chunking/document-chunker.ts
+++ b/src/ingestion/chunking/document-chunker.ts
@@ -23,6 +23,17 @@ function splitIntoSentences(text: string): string[] {
   );
 }
 
+function splitOversizedWord(word: string, maxTokens: number): string[] {
+  const tokens = encoding.encode(word);
+  const pieces: string[] = [];
+
+  for (let i = 0; i < tokens.length; i += maxTokens) {
+    pieces.push(encoding.decode(tokens.slice(i, i + maxTokens)));
+  }
+
+  return pieces;
+}
+
 function addChunk(
   chunks: JournalDocument[],
   document: JournalDocument,
@@ -109,6 +120,17 @@ export function chunkDocument(
 
         if (countTokens(candidate) <= maxTokens) {
           sentenceChunk = candidate;
+        } else if (countTokens(word) > maxTokens) {
+          if (sentenceChunk) {
+            addChunk(chunks, document, sentenceChunk);
+          }
+
+          const pieces = splitOversizedWord(word, maxTokens);
+          for (const piece of pieces.slice(0, -1)) {
+            addChunk(chunks, document, piece);
+          }
+
+          sentenceChunk = pieces[pieces.length - 1] ?? '';
         } else {
           if (sentenceChunk) {
             addChunk(chunks, document, sentenceChunk);

--- a/src/ingestion/chunking/document-chunker.ts
+++ b/src/ingestion/chunking/document-chunker.ts
@@ -33,20 +33,38 @@ function splitOversizedWord(word: string, maxTokens: number): string[] {
   let start = 0;
 
   while (start < chars.length) {
-    let lo = start + 1;
-    let hi = chars.length;
+    const remaining = chars.length - start;
+
+    // Exponentially grow the candidate length to bound the search window
+    // near the true boundary first, rather than binary-searching the full
+    // remaining word on every piece — that re-tokenizes long suffixes and
+    // scales quadratically for large whitespace-free inputs.
+    let fit = 1;
+    let probe = 2;
+
+    while (
+      probe <= remaining &&
+      countTokens(chars.slice(start, start + probe).join('')) <= maxTokens
+    ) {
+      fit = probe;
+      probe *= 2;
+    }
+
+    let lo = fit;
+    let hi = Math.min(probe, remaining);
 
     while (lo < hi) {
-      const mid = Math.ceil((lo + hi) / 2);
-      if (countTokens(chars.slice(start, mid).join('')) <= maxTokens) {
+      const mid = lo + Math.ceil((hi - lo) / 2);
+      if (countTokens(chars.slice(start, start + mid).join('')) <= maxTokens) {
         lo = mid;
       } else {
         hi = mid - 1;
       }
     }
 
-    pieces.push(chars.slice(start, lo).join(''));
-    start = lo;
+    const pieceLength = Math.max(lo, 1);
+    pieces.push(chars.slice(start, start + pieceLength).join(''));
+    start += pieceLength;
   }
 
   return pieces;
@@ -71,6 +89,10 @@ export function chunkDocument(
   document: JournalDocument,
   maxTokens: number = DEFAULT_MAX_TOKENS,
 ): JournalDocument[] {
+  if (maxTokens < 1) {
+    throw new Error(`maxTokens must be at least 1, received ${maxTokens}`);
+  }
+
   // Keep small journal records intact.
   if (countTokens(document.content) <= maxTokens) {
     return [document];

--- a/tests/chunker.test.ts
+++ b/tests/chunker.test.ts
@@ -121,4 +121,23 @@ describe('Document Chunker', () => {
 
     expect(chunks.map((chunk) => chunk.content).join('')).toContain(longWord);
   });
+
+  it('splits an oversized multi-byte word without corrupting characters', () => {
+    const longWord = '日本語テスト'.repeat(40);
+    const oversizedWordDocument: JournalDocument = {
+      content: `Short intro sentence here. ${longWord} tail.`,
+      metadata: oversizedSentenceDocument.metadata,
+    };
+
+    const chunks = chunkDocument(oversizedWordDocument, 20);
+
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (const chunk of chunks) {
+      expect(countTokens(chunk.content)).toBeLessThanOrEqual(20);
+      expect(chunk.content).not.toContain('�');
+    }
+
+    expect(chunks.map((chunk) => chunk.content).join('')).toContain(longWord);
+  });
 });

--- a/tests/chunker.test.ts
+++ b/tests/chunker.test.ts
@@ -140,4 +140,9 @@ describe('Document Chunker', () => {
 
     expect(chunks.map((chunk) => chunk.content).join('')).toContain(longWord);
   });
+
+  it('rejects a maxTokens value below one', () => {
+    expect(() => chunkDocument(smallDocument, 0)).toThrow();
+    expect(() => chunkDocument(smallDocument, -1)).toThrow();
+  });
 });

--- a/tests/chunker.test.ts
+++ b/tests/chunker.test.ts
@@ -103,4 +103,22 @@ describe('Document Chunker', () => {
       expect(countTokens(chunk.content)).toBeLessThanOrEqual(20);
     }
   });
+
+  it('splits a single word that exceeds the token limit', () => {
+    const longWord = 'a'.repeat(400);
+    const oversizedWordDocument: JournalDocument = {
+      content: `Short intro sentence here. ${longWord} tail.`,
+      metadata: oversizedSentenceDocument.metadata,
+    };
+
+    const chunks = chunkDocument(oversizedWordDocument, 20);
+
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (const chunk of chunks) {
+      expect(countTokens(chunk.content)).toBeLessThanOrEqual(20);
+    }
+
+    expect(chunks.map((chunk) => chunk.content).join('')).toContain(longWord);
+  });
 });

--- a/tests/chunker.test.ts
+++ b/tests/chunker.test.ts
@@ -144,5 +144,6 @@ describe('Document Chunker', () => {
   it('rejects a maxTokens value below one', () => {
     expect(() => chunkDocument(smallDocument, 0)).toThrow();
     expect(() => chunkDocument(smallDocument, -1)).toThrow();
+    expect(() => chunkDocument(smallDocument, NaN)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- `chunkDocument()` had no fallback below word-level splitting, so a single whitespace-free word longer than `maxTokens` (long URL, base64 blob, pasted identifier) was emitted as an oversized chunk unmodified.
- Added `splitOversizedWord()` to hard-split such words by token count as a final fallback, keeping every emitted chunk within `maxTokens`.
- Added a regression test reproducing the issue's repro case.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — chunker unit tests pass (7 pre-existing integration-test failures are unrelated, due to no live Postgres instance in this environment)

Fixes #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document chunking for words that exceed the token limit.
  * Preserves complete word content while splitting oversized words into manageable chunks.
  * Correctly handles multi-byte characters without producing corrupted text.

* **Tests**
  * Added coverage for oversized words and multi-byte text splitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->