### PR TITLE
fix: chunkDocument returns no chunks for empty/whitespace content

### DIFF
--- a/src/ingestion/chunking/document-chunker.ts
+++ b/src/ingestion/chunking/document-chunker.ts
@@ -42,6 +42,10 @@ export function chunkDocument(
   document: JournalDocument,
   maxTokens: number = DEFAULT_MAX_TOKENS,
 ): JournalDocument[] {
+  if (!document.content.trim()) {
+    return [];
+  }
+
   // Keep small journal records intact.
   if (countTokens(document.content) <= maxTokens) {
     return [document];

--- a/tests/chunker.test.ts
+++ b/tests/chunker.test.ts
@@ -55,6 +55,15 @@ const oversizedSentenceDocument: JournalDocument = {
 };
 
 describe('Document Chunker', () => {
+  it('returns no chunks for whitespace-only content', () => {
+    const whitespaceDocument: JournalDocument = {
+      ...smallDocument,
+      content: '   \n\t  ',
+    };
+
+    expect(chunkDocument(whitespaceDocument, 100)).toHaveLength(0);
+  });
+
   it('keeps a small document as a single chunk', () => {
     const chunks = chunkDocument(smallDocument, 100);
 
@@ -111,9 +120,7 @@ describe('Document Chunker', () => {
     });
   });
 
-  it.failing('does not create chunks for empty content', () => {
-    // Tracked in #59: chunkDocument currently returns the empty document
-    // unchanged instead of producing zero chunks.
+  it('does not create chunks for empty content', () => {
     const emptyDocument: JournalDocument = {
       ...smallDocument,
       content: '',

--- a/tests/chunker.test.ts
+++ b/tests/chunker.test.ts
@@ -80,6 +80,50 @@ describe('Document Chunker', () => {
     });
   });
 
+  it('keeps multiple small documents separate', () => {
+    const secondDocument: JournalDocument = {
+      ...smallDocument,
+      content: 'A second short journal entry with unrelated content.',
+      metadata: { ...smallDocument.metadata, sourceId: 3 },
+    };
+    const thirdDocument: JournalDocument = {
+      ...smallDocument,
+      content: 'A third short journal entry, also unrelated.',
+      metadata: { ...smallDocument.metadata, sourceId: 4 },
+    };
+
+    const chunks = chunkDocuments(
+      [smallDocument, secondDocument, thirdDocument],
+      100,
+    );
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0].content).toBe(smallDocument.content);
+    expect(chunks[1].content).toBe(secondDocument.content);
+    expect(chunks[2].content).toBe(thirdDocument.content);
+  });
+
+  it('does not split chunks mid-sentence', () => {
+    const chunks = chunkDocument(largeDocument, 30);
+
+    chunks.forEach((chunk) => {
+      expect(chunk.content.trim()).toMatch(/[.!?]$/);
+    });
+  });
+
+  it.failing('does not create chunks for empty content', () => {
+    // Tracked in #59: chunkDocument currently returns the empty document
+    // unchanged instead of producing zero chunks.
+    const emptyDocument: JournalDocument = {
+      ...smallDocument,
+      content: '',
+    };
+
+    const chunks = chunkDocument(emptyDocument, 100);
+
+    expect(chunks).toHaveLength(0);
+  });
+
   it('flattens multiple documents', () => {
     const chunks = chunkDocuments([smallDocument, largeDocument], 30);
 
@@ -94,8 +138,6 @@ describe('Document Chunker', () => {
 
   it('splits a sentence that exceeds the token limit', () => {
     const chunks = chunkDocument(oversizedSentenceDocument, 20);
-
-    console.log(chunks);
 
     expect(chunks.length).toBeGreaterThan(1);
 


### PR DESCRIPTION
## Summary
- `chunkDocument`'s fast path bypassed the empty-content guard, returning a single empty chunk instead of zero for empty/whitespace-only documents — contradicting the documented invariant in `docs/03-chunker-architecture.md`.
- Added the guard, converted the existing `it.failing` regression test (written for this exact bug) into a passing test, and added a whitespace-only case.

Fixes #59

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test -- tests/chunker.test.ts` (9/9 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URwBpgpUiimiWssCUjULef