### PR TITLE
feat: data-driven chunk-size tuning tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Set the following environment variables (see `.env.example` for a starting point
 | `EMBEDDING_API_URL` | No | Defaults to `http://127.0.0.1:8000` |
 | `EMBEDDING_API_TIMEOUT_MS` | No | Defaults to 30000 |
 | `PORT` | No | Defaults to 3000 |
-| `CHUNK_MAX_TOKENS` | No | Max tokens per document chunk during ingestion (`src/ingestion/chunking/document-chunker.ts`). Defaults to 300 — see `docs/02-architecture.md` D4 for how that default was chosen. |
+| `CHUNK_MAX_TOKENS` | No | Overrides max tokens per document chunk for every `sourceType` during ingestion, bypassing `SOURCE_TYPE_CHUNK_CONFIG`'s per-`sourceType` defaults (`src/ingestion/chunking/document-chunker.ts`). Leave unset to let each `sourceType` use its own configured default (currently 300 for all of them — see `docs/02-architecture.md` D4). |
 | `ALLOWED_ORIGIN` | No | Comma-separated list of allowed CORS origins. Unset reflects the request's own origin (no restriction) — low value until a real frontend is deployed at a known origin, at which point set this to lock CORS down. |
 
 ### Database

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm install
 
 ### Configure environment
 
-Set the following environment variables (see `.env.example` for a starting point — note it does not currently list `EMBEDDING_API_URL`, `EMBEDDING_API_TIMEOUT_MS`, or `PORT`, since all three are optional with defaults):
+Set the following environment variables (see `.env.example` for a starting point — note it does not currently list `EMBEDDING_API_URL`, `EMBEDDING_API_TIMEOUT_MS`, `PORT`, or `CHUNK_MAX_TOKENS`, since all four are optional with defaults):
 
 | Variable | Required | Notes |
 |---|---|---|
@@ -67,6 +67,7 @@ Set the following environment variables (see `.env.example` for a starting point
 | `EMBEDDING_API_URL` | No | Defaults to `http://127.0.0.1:8000` |
 | `EMBEDDING_API_TIMEOUT_MS` | No | Defaults to 30000 |
 | `PORT` | No | Defaults to 3000 |
+| `CHUNK_MAX_TOKENS` | No | Max tokens per document chunk during ingestion (`src/ingestion/chunking/document-chunker.ts`). Defaults to 300 — see `docs/02-architecture.md` D4 for how that default was chosen. |
 | `ALLOWED_ORIGIN` | No | Comma-separated list of allowed CORS origins. Unset reflects the request's own origin (no restriction) — low value until a real frontend is deployed at a known origin, at which point set this to lock CORS down. |
 
 ### Database
@@ -225,3 +226,17 @@ npm run test:integration # runs just the integration suite explicitly/serially
 includes the PostgreSQL + pgvector integration suite — CI provisions a pgvector database
 specifically for this. `npm run test:integration` just runs that same subset explicitly/serially,
 useful for running it in isolation locally.
+
+### Chunk-size evaluation sweep
+
+```bash
+DATABASE_ENV=development npm run eval:chunk-size
+```
+
+Re-ingests the seeded dev dataset and re-runs the AI-system evaluation harness
+(`evaluation/ai-system/`) at several `CHUNK_MAX_TOKENS` candidates, printing a comparison table of
+retrieval/citation/faithfulness pass rates per size. Needs the same setup as `npm run ingest` (a
+seeded `injury-journal-ai-db`, the embedding service running, `GROQ_API_KEY` set) plus
+`DATABASE_ENV=development` as a guard against running it against the wrong database — it re-runs
+ingestion multiple times in a loop, so it's more destructive than a single `npm run ingest`. See
+`docs/02-architecture.md` D4 for the last recorded result.

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -639,6 +639,13 @@ quoted), what else was considered, whether it still holds, and whether it should
     than a transient rate limit. Re-run `npm run eval:chunk-size` once quota resets and update this
     note; overlap changes what content lands in each chunk, so it could plausibly shift retrieval
     even though chunk size alone didn't.
+  - **Interaction with #218 (`SOURCE_TYPE_CHUNK_CONFIG`):** the sweep sets an explicit `maxTokens`
+    for every document (uniformly, across all `sourceType`s) via `runIngestion`, which per
+    `docs/03-chunker-architecture.md` overrides `SOURCE_TYPE_CHUNK_CONFIG` entirely — the sweep
+    only answers "what should the one global default be," not "should different sourceTypes use
+    different budgets." `CHUNK_MAX_TOKENS` (see README) is `undefined` unless explicitly set, so
+    real ingestion (`npm run ingest`) still defers to `SOURCE_TYPE_CHUNK_CONFIG` normally; only the
+    sweep (and anyone who sets `CHUNK_MAX_TOKENS`) forces a single value across every sourceType.
 
 ### D5 — Plain top-k cosine retrieval; no similarity threshold, hybrid search, or reranking
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -623,6 +623,14 @@ quoted), what else was considered, whether it still holds, and whether it should
   is no dedup/diversity step downstream, which is an accepted tradeoff for now given the small
   corpus size, not a bug.
 - **SHOULD THIS BE REVISITED:** No.
+- **`DEFAULT_MAX_TOKENS` (300) is now measured, not assumed (#137):** `evaluation/ai-system/chunk-size-sweep.ts`
+  (`npm run eval:chunk-size`) re-ingests the seeded dev dataset and re-runs the eval harness at
+  maxTokens = 150/300/450/600. Result: retrieval (20/21) and citations (21/21) were identical across
+  all four sizes — most journal records are short enough to fit in one chunk regardless of the
+  limit, so chunk size rarely changes what gets chunked/retrieved for this dataset. Faithfulness
+  (LLM-judged, so somewhat noisy) was 19/21, 21/21, 19/21, 20/21 respectively, with 300 scoring
+  best. No value beat 300 on any metric, so the default was left unchanged. Re-run the sweep if the
+  eval dataset grows to include longer records, or if this stops holding.
 
 ### D5 — Plain top-k cosine retrieval; no similarity threshold, hybrid search, or reranking
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -625,12 +625,15 @@ quoted), what else was considered, whether it still holds, and whether it should
 - **SHOULD THIS BE REVISITED:** No.
 - **`DEFAULT_MAX_TOKENS` (300) is now measured, not assumed (#137):** `evaluation/ai-system/chunk-size-sweep.ts`
   (`npm run eval:chunk-size`) re-ingests the seeded dev dataset and re-runs the eval harness at
-  maxTokens = 150/300/450/600. Result: retrieval (20/21) and citations (21/21) were identical across
-  all four sizes — most journal records are short enough to fit in one chunk regardless of the
-  limit, so chunk size rarely changes what gets chunked/retrieved for this dataset. Faithfulness
-  (LLM-judged, so somewhat noisy) was 19/21, 21/21, 19/21, 20/21 respectively, with 300 scoring
-  best. No value beat 300 on any metric, so the default was left unchanged. Re-run the sweep if the
-  eval dataset grows to include longer records, or if this stops holding.
+  maxTokens = 150/300/450/600. First result (measured before `QWEN_SAFETY_MARGIN` above existed, so
+  the actual effective split budgets tested were 150/300/450/600 rather than the ~123/246/369/492
+  now in effect): retrieval (20/21) and citations (21/21) were identical across all four sizes —
+  most journal records are short enough to fit in one chunk regardless of the limit, so chunk size
+  rarely changes what gets chunked/retrieved for this dataset. Faithfulness (LLM-judged, so somewhat
+  noisy) was 19/21, 21/21, 19/21, 20/21 respectively, with 300 scoring best. No value beat 300 on
+  any metric, so the default was left unchanged, but this specific result should be re-verified
+  against the post-safety-margin chunker. Re-run the sweep if the eval dataset grows to include
+  longer records, if `QWEN_SAFETY_MARGIN` changes, or if this stops holding.
 
 ### D5 — Plain top-k cosine retrieval; no similarity threshold, hybrid search, or reranking
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -626,13 +626,19 @@ quoted), what else was considered, whether it still holds, and whether it should
 - **`DEFAULT_MAX_TOKENS` (300) is now measured, not assumed (#137):** `evaluation/ai-system/chunk-size-sweep.ts`
   (`npm run eval:chunk-size`) re-ingests the seeded dev dataset and re-runs the eval harness at
   maxTokens = 150/300/450/600 (effective split budgets ~123/246/369/492 after `QWEN_SAFETY_MARGIN`
-  above). Result, verified against the post-safety-margin chunker: retrieval (20/21) and citations
-  (21/21) were identical across all four sizes — most journal records are short enough to fit in
-  one chunk regardless of the limit, so chunk size rarely changes what gets chunked/retrieved for
-  this dataset. Faithfulness (LLM-judged, so somewhat noisy) was 19/21, 21/21, 19/21, 20/21
-  respectively, with 300 scoring best. No value beat 300 on any metric, so the default was left
-  unchanged. Re-run the sweep if the eval dataset grows to include longer records, if
-  `QWEN_SAFETY_MARGIN` changes, or if this stops holding.
+  above). Result, verified against the post-safety-margin chunker (but not yet re-verified against
+  chunk overlap, #214 — see below): retrieval (20/21) and citations (21/21) were identical across
+  all four sizes — most journal records are short enough to fit in one chunk regardless of the
+  limit, so chunk size rarely changes what gets chunked/retrieved for this dataset. Faithfulness
+  (LLM-judged, so somewhat noisy) was 19/21, 21/21, 19/21, 20/21 respectively, with 300 scoring
+  best. No value beat 300 on any metric, so the default was left unchanged. Re-run the sweep if the
+  eval dataset grows to include longer records, if `QWEN_SAFETY_MARGIN` changes, or if this stops
+  holding.
+  - **Pending:** #214 (chunk overlap, default-on) merged after this was last measured. The sweep
+    hasn't been re-run against it yet — the attempt hit Groq's daily token quota (200k TPD) rather
+    than a transient rate limit. Re-run `npm run eval:chunk-size` once quota resets and update this
+    note; overlap changes what content lands in each chunk, so it could plausibly shift retrieval
+    even though chunk size alone didn't.
 
 ### D5 — Plain top-k cosine retrieval; no similarity threshold, hybrid search, or reranking
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -625,15 +625,14 @@ quoted), what else was considered, whether it still holds, and whether it should
 - **SHOULD THIS BE REVISITED:** No.
 - **`DEFAULT_MAX_TOKENS` (300) is now measured, not assumed (#137):** `evaluation/ai-system/chunk-size-sweep.ts`
   (`npm run eval:chunk-size`) re-ingests the seeded dev dataset and re-runs the eval harness at
-  maxTokens = 150/300/450/600. First result (measured before `QWEN_SAFETY_MARGIN` above existed, so
-  the actual effective split budgets tested were 150/300/450/600 rather than the ~123/246/369/492
-  now in effect): retrieval (20/21) and citations (21/21) were identical across all four sizes —
-  most journal records are short enough to fit in one chunk regardless of the limit, so chunk size
-  rarely changes what gets chunked/retrieved for this dataset. Faithfulness (LLM-judged, so somewhat
-  noisy) was 19/21, 21/21, 19/21, 20/21 respectively, with 300 scoring best. No value beat 300 on
-  any metric, so the default was left unchanged, but this specific result should be re-verified
-  against the post-safety-margin chunker. Re-run the sweep if the eval dataset grows to include
-  longer records, if `QWEN_SAFETY_MARGIN` changes, or if this stops holding.
+  maxTokens = 150/300/450/600 (effective split budgets ~123/246/369/492 after `QWEN_SAFETY_MARGIN`
+  above). Result, verified against the post-safety-margin chunker: retrieval (20/21) and citations
+  (21/21) were identical across all four sizes — most journal records are short enough to fit in
+  one chunk regardless of the limit, so chunk size rarely changes what gets chunked/retrieved for
+  this dataset. Faithfulness (LLM-judged, so somewhat noisy) was 19/21, 21/21, 19/21, 20/21
+  respectively, with 300 scoring best. No value beat 300 on any metric, so the default was left
+  unchanged. Re-run the sweep if the eval dataset grows to include longer records, if
+  `QWEN_SAFETY_MARGIN` changes, or if this stops holding.
 
 ### D5 — Plain top-k cosine retrieval; no similarity threshold, hybrid search, or reranking
 

--- a/evaluation/ai-system/chunk-size-sweep.ts
+++ b/evaluation/ai-system/chunk-size-sweep.ts
@@ -3,9 +3,10 @@ import { runEvaluation } from './evaluation-runner.js';
 import { generateEvaluationReport } from './evaluation-report.js';
 import { prisma } from '../../src/lib/prisma.js';
 
-// Sweeps maxTokens only. #214 (chunk overlap) is open but unmerged as of
-// this writing -- once it lands, extend this sweep to also vary
-// overlapTokens rather than treating maxTokens as the only knob.
+// Sweeps maxTokens only; overlapTokens (#214) is left at chunkDocument's own
+// default at every candidate. Extend this to also vary overlapTokens if
+// overlap tuning is ever in scope -- for now this only answers the maxTokens
+// question #137 was scoped to.
 const CANDIDATE_MAX_TOKENS = [150, 300, 450, 600];
 
 // This re-ingests every document in whatever DATABASE_URL points at, once

--- a/evaluation/ai-system/chunk-size-sweep.ts
+++ b/evaluation/ai-system/chunk-size-sweep.ts
@@ -1,0 +1,48 @@
+import { runIngestion } from '../../src/ingestion/ingestion-worker.js';
+import { runEvaluation } from './evaluation-runner.js';
+import { generateEvaluationReport } from './evaluation-report.js';
+import { prisma } from '../../src/lib/prisma.js';
+
+// Sweeps maxTokens only, matching the chunker as it exists on main today.
+// PRs #213 (Qwen3 tokenizer safety margin) and #214 (chunk overlap) are open
+// but unmerged as of this writing -- once either lands, extend this sweep to
+// also vary overlapTokens / account for the safety margin rather than
+// treating maxTokens as the only knob.
+const CANDIDATE_MAX_TOKENS = [150, 300, 450, 600];
+
+async function main() {
+  const rows: Record<string, string | number>[] = [];
+
+  for (const maxTokens of CANDIDATE_MAX_TOKENS) {
+    console.log(`Re-ingesting with maxTokens=${maxTokens}...`);
+    const ingestionResult = await runIngestion(maxTokens);
+
+    if (ingestionResult.failed.length > 0) {
+      throw new Error(
+        `Ingestion failed for ${ingestionResult.failed.length}/${ingestionResult.total} ` +
+          `document(s) at maxTokens=${maxTokens}; aborting sweep.`,
+      );
+    }
+
+    const results = await runEvaluation();
+    const report = generateEvaluationReport(results);
+
+    rows.push({
+      maxTokens,
+      retrieval: `${report.retrieval.passed}/${report.retrieval.total}`,
+      citations: `${report.citations.passed}/${report.citations.total}`,
+      faithfulness: `${report.faithfulness.passed}/${report.faithfulness.total}`,
+    });
+  }
+
+  console.table(rows);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/evaluation/ai-system/chunk-size-sweep.ts
+++ b/evaluation/ai-system/chunk-size-sweep.ts
@@ -3,14 +3,40 @@ import { runEvaluation } from './evaluation-runner.js';
 import { generateEvaluationReport } from './evaluation-report.js';
 import { prisma } from '../../src/lib/prisma.js';
 
-// Sweeps maxTokens only, matching the chunker as it exists on main today.
-// PRs #213 (Qwen3 tokenizer safety margin) and #214 (chunk overlap) are open
-// but unmerged as of this writing -- once either lands, extend this sweep to
-// also vary overlapTokens / account for the safety margin rather than
-// treating maxTokens as the only knob.
+// Sweeps maxTokens only. #214 (chunk overlap) is open but unmerged as of
+// this writing -- once it lands, extend this sweep to also vary
+// overlapTokens rather than treating maxTokens as the only knob.
 const CANDIDATE_MAX_TOKENS = [150, 300, 450, 600];
 
+// This re-ingests every document in whatever DATABASE_URL points at, once
+// per candidate. Guarded the same way prisma/seed-dev.ts guards its own
+// destructive dev-only operation, since a misconfigured DATABASE_URL here
+// would otherwise silently re-chunk/re-embed real data multiple times.
+function assertSafeToRunAgainstThisDatabase(): void {
+  if (process.env.DATABASE_ENV !== 'development') {
+    throw new Error(
+      'Refusing to run the chunk-size sweep: DATABASE_ENV must be "development".',
+    );
+  }
+
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw new Error('Refusing to run the chunk-size sweep: DATABASE_URL is not set.');
+  }
+
+  const databaseName = new URL(databaseUrl).pathname.slice(1);
+
+  if (databaseName !== 'injury-journal-ai-db') {
+    throw new Error(
+      `Refusing to run the chunk-size sweep: unexpected database "${databaseName}".`,
+    );
+  }
+}
+
 async function main() {
+  assertSafeToRunAgainstThisDatabase();
+
   const rows: Record<string, string | number>[] = [];
 
   for (const maxTokens of CANDIDATE_MAX_TOKENS) {

--- a/evaluation/ai-system/evaluation-runner.ts
+++ b/evaluation/ai-system/evaluation-runner.ts
@@ -11,11 +11,65 @@ import { evaluateRetrieval } from './retrieval-metrics.js';
 import { evaluateFaithfulness } from './faithfulness-judge.js';
 import type { EvaluationResult } from './evaluation-types.js';
 
+const MAX_RATE_LIMIT_RETRIES = 5;
+
+function isRateLimitError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { status?: unknown }).status === 429
+  );
+}
+
+function getRetryDelayMs(error: unknown, attempt: number): number {
+  const headers = (error as { headers?: unknown } | undefined)?.headers;
+  const retryAfter =
+    headers && typeof (headers as Headers).get === 'function'
+      ? (headers as Headers).get('retry-after')
+      : undefined;
+
+  const seconds = retryAfter ? Number(retryAfter) : NaN;
+  if (Number.isFinite(seconds)) {
+    return seconds * 1000;
+  }
+
+  // No Retry-After header: back off exponentially, capped at 30s.
+  return Math.min(2 ** attempt * 1000, 30_000);
+}
+
+// Groq's free tier enforces a low tokens-per-minute cap, which a full
+// evaluation pass (let alone a chunk-size sweep running several passes back
+// to back, see chunk-size-sweep.ts) can exceed mid-run. Retrying here keeps
+// one rate-limited item from aborting the entire evaluation run.
+async function runAgentWithRetry(
+  ...args: Parameters<typeof runAgent>
+): ReturnType<typeof runAgent> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await runAgent(...args);
+    } catch (error) {
+      if (!isRateLimitError(error) || attempt >= MAX_RATE_LIMIT_RETRIES) {
+        throw error;
+      }
+
+      const delayMs = getRetryDelayMs(error, attempt);
+      console.warn(
+        `Rate limited by the LLM provider, retrying in ${Math.ceil(delayMs / 1000)}s...`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}
+
 export async function runEvaluation() {
   const results: EvaluationResult[] = [];
 
   for (const item of dataset) {
-    const output = await runAgent(item.question, item.userId, item.injuryId);
+    const output = await runAgentWithRetry(
+      item.question,
+      item.userId,
+      item.injuryId,
+    );
 
     results.push({
       id: item.id,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:integration": "cross-env NODE_ENV=test node --experimental-vm-modules node_modules/jest/bin/jest.js tests/integration --maxWorkers=1",
     "seed:dev": "tsx prisma/seed-dev.ts",
-    "ingest": "tsx src/ingestion/ingestion-worker.ts"
+    "ingest": "tsx src/ingestion/ingestion-worker.ts",
+    "eval:chunk-size": "tsx evaluation/ai-system/chunk-size-sweep.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/src/config/chunking.ts
+++ b/src/config/chunking.ts
@@ -1,15 +1,29 @@
-import { DEFAULT_MAX_TOKENS } from '../ingestion/chunking/document-chunker.js';
+// Unset (the common case) resolves to `undefined`, not a hardcoded number:
+// chunkDocument/chunkDocuments treat an explicit maxTokens as an override
+// that wins over SOURCE_TYPE_CHUNK_CONFIG's per-sourceType defaults (see
+// document-chunker.ts). Defaulting this to DEFAULT_MAX_TOKENS would silently
+// force that same value onto every sourceType during real ingestion,
+// permanently short-circuiting per-sourceType tuning. Only set
+// CHUNK_MAX_TOKENS when you actually want to override every sourceType at
+// once (e.g. the chunk-size sweep).
+const rawMaxTokens = process.env.CHUNK_MAX_TOKENS;
 
-const rawMaxTokens = process.env.CHUNK_MAX_TOKENS ?? String(DEFAULT_MAX_TOKENS);
+const CHUNK_MAX_TOKENS: number | undefined = (() => {
+  if (rawMaxTokens === undefined) {
+    return undefined;
+  }
 
-if (rawMaxTokens.trim() === '') {
-  throw new Error(`Invalid CHUNK_MAX_TOKENS: ${rawMaxTokens}`);
-}
+  if (rawMaxTokens.trim() === '') {
+    throw new Error(`Invalid CHUNK_MAX_TOKENS: ${rawMaxTokens}`);
+  }
 
-const CHUNK_MAX_TOKENS = Number(rawMaxTokens);
+  const parsed = Number(rawMaxTokens);
 
-if (!Number.isInteger(CHUNK_MAX_TOKENS) || CHUNK_MAX_TOKENS < 1) {
-  throw new Error(`Invalid CHUNK_MAX_TOKENS: ${rawMaxTokens}`);
-}
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`Invalid CHUNK_MAX_TOKENS: ${rawMaxTokens}`);
+  }
+
+  return parsed;
+})();
 
 export { CHUNK_MAX_TOKENS };

--- a/src/config/chunking.ts
+++ b/src/config/chunking.ts
@@ -1,0 +1,15 @@
+import { DEFAULT_MAX_TOKENS } from '../ingestion/chunking/document-chunker.js';
+
+const rawMaxTokens = process.env.CHUNK_MAX_TOKENS ?? String(DEFAULT_MAX_TOKENS);
+
+if (rawMaxTokens.trim() === '') {
+  throw new Error(`Invalid CHUNK_MAX_TOKENS: ${rawMaxTokens}`);
+}
+
+const CHUNK_MAX_TOKENS = Number(rawMaxTokens);
+
+if (!Number.isInteger(CHUNK_MAX_TOKENS) || CHUNK_MAX_TOKENS < 1) {
+  throw new Error(`Invalid CHUNK_MAX_TOKENS: ${rawMaxTokens}`);
+}
+
+export { CHUNK_MAX_TOKENS };

--- a/src/ingestion/chunking/document-chunker.ts
+++ b/src/ingestion/chunking/document-chunker.ts
@@ -4,7 +4,7 @@ import type {
   JournalDocument,
 } from '../documents/document-types.js';
 
-const DEFAULT_MAX_TOKENS = 300;
+export const DEFAULT_MAX_TOKENS = 300;
 const DEFAULT_OVERLAP_TOKENS = 50;
 
 // Per-sourceType overrides for chunking budgets. Every entry currently

--- a/src/ingestion/embed-and-store.ts
+++ b/src/ingestion/embed-and-store.ts
@@ -10,12 +10,13 @@ import { withIngestionLock } from './ingestion-lock.js';
 
 export async function embedAndStoreDocument(
   document: JournalDocument,
+  maxTokens?: number,
 ): Promise<void> {
   await withIngestionLock(
     document.metadata.sourceType,
     document.metadata.sourceId,
     async () => {
-      const chunks = chunkDocument(document);
+      const chunks = chunkDocument(document, maxTokens);
 
       for (const [chunkIndex, chunk] of chunks.entries()) {
         const embedding = await embedText(chunk.content);

--- a/src/ingestion/ingestion-worker.ts
+++ b/src/ingestion/ingestion-worker.ts
@@ -4,6 +4,7 @@ import { readJournalData } from './reader/postgres-reader.js';
 import { buildJournalDocuments } from './documents/document-builder.js';
 import { embedAndStoreDocument } from './embed-and-store.js';
 import { logError } from '../lib/log-error.js';
+import { CHUNK_MAX_TOKENS } from '../config/chunking.js';
 import type { JournalDocument } from './documents/document-types.js';
 
 export interface IngestionFailure {
@@ -40,7 +41,9 @@ export interface IngestionResult {
  * is already durably committed and stays that way regardless of what
  * happens to documents processed afterward.
  */
-export async function runIngestion(): Promise<IngestionResult> {
+export async function runIngestion(
+  maxTokens: number = CHUNK_MAX_TOKENS,
+): Promise<IngestionResult> {
   const injuries = await readJournalData();
 
   let documents: JournalDocument[];
@@ -63,7 +66,7 @@ export async function runIngestion(): Promise<IngestionResult> {
 
   for (const document of documents) {
     try {
-      await embedAndStoreDocument(document);
+      await embedAndStoreDocument(document, maxTokens);
       result.succeeded += 1;
     } catch (error) {
       logError(

--- a/src/ingestion/ingestion-worker.ts
+++ b/src/ingestion/ingestion-worker.ts
@@ -42,7 +42,7 @@ export interface IngestionResult {
  * happens to documents processed afterward.
  */
 export async function runIngestion(
-  maxTokens: number = CHUNK_MAX_TOKENS,
+  maxTokens: number | undefined = CHUNK_MAX_TOKENS,
 ): Promise<IngestionResult> {
   const injuries = await readJournalData();
 

--- a/tests/chunking-config.test.ts
+++ b/tests/chunking-config.test.ts
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+
+describe('CHUNK_MAX_TOKENS env parsing', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test.each([
+    [undefined, 300],
+    ['300', 300],
+    ['150', 150],
+    ['1', 1],
+  ])('CHUNK_MAX_TOKENS=%p resolves to %p', async (value, expected) => {
+    if (value === undefined) {
+      delete process.env.CHUNK_MAX_TOKENS;
+    } else {
+      process.env.CHUNK_MAX_TOKENS = value;
+    }
+
+    const { CHUNK_MAX_TOKENS } = await import('../src/config/chunking');
+    expect(CHUNK_MAX_TOKENS).toBe(expected);
+  });
+
+  test.each([['0'], ['-1'], ['abc'], [''], ['   ']])(
+    'CHUNK_MAX_TOKENS=%p throws',
+    async (value) => {
+      process.env.CHUNK_MAX_TOKENS = value;
+
+      await expect(import('../src/config/chunking')).rejects.toThrow(
+        /Invalid CHUNK_MAX_TOKENS/,
+      );
+    },
+  );
+});

--- a/tests/chunking-config.test.ts
+++ b/tests/chunking-config.test.ts
@@ -13,7 +13,7 @@ describe('CHUNK_MAX_TOKENS env parsing', () => {
   });
 
   test.each([
-    [undefined, 300],
+    [undefined, undefined],
     ['300', 300],
     ['150', 150],
     ['1', 1],

--- a/tests/embed-and-store.test.ts
+++ b/tests/embed-and-store.test.ts
@@ -137,7 +137,7 @@ describe('embedAndStoreDocument', () => {
 
     await embedAndStoreDocument(document);
 
-    expect(chunkDocumentMock).toHaveBeenCalledWith(document);
+    expect(chunkDocumentMock).toHaveBeenCalledWith(document, undefined);
     expect(embedTextMock).toHaveBeenCalledTimes(2);
     expect(embedTextMock).toHaveBeenNthCalledWith(1, 'chunk one');
     expect(embedTextMock).toHaveBeenNthCalledWith(2, 'chunk two');

--- a/tests/ingestion-worker.test.ts
+++ b/tests/ingestion-worker.test.ts
@@ -16,7 +16,7 @@ const buildJournalDocumentsMock =
   jest.fn<(injuries: InjuryWithRelations[]) => JournalDocument[]>();
 
 const embedAndStoreDocumentMock =
-  jest.fn<(document: JournalDocument) => Promise<void>>();
+  jest.fn<(document: JournalDocument, maxTokens?: number) => Promise<void>>();
 
 jest.unstable_mockModule('../src/ingestion/reader/postgres-reader.js', () => ({
   readJournalData: readJournalDataMock,
@@ -72,9 +72,9 @@ describe('runIngestion', () => {
     const result = await runIngestion();
 
     expect(embedAndStoreDocumentMock).toHaveBeenCalledTimes(3);
-    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(1, documents[0]);
-    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(2, documents[1]);
-    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(3, documents[2]);
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(1, documents[0], 300);
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(2, documents[1], 300);
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(3, documents[2], 300);
 
     expect(result).toEqual({ total: 3, succeeded: 3, failed: [] });
   });

--- a/tests/ingestion-worker.test.ts
+++ b/tests/ingestion-worker.test.ts
@@ -72,11 +72,30 @@ describe('runIngestion', () => {
     const result = await runIngestion();
 
     expect(embedAndStoreDocumentMock).toHaveBeenCalledTimes(3);
-    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(1, documents[0], 300);
-    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(2, documents[1], 300);
-    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(3, documents[2], 300);
+    // undefined by default (CHUNK_MAX_TOKENS unset): each document's
+    // sourceType-specific config decides its own chunk size, rather than
+    // this worker forcing a single value onto every document.
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(1, documents[0], undefined);
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(2, documents[1], undefined);
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(3, documents[2], undefined);
 
     expect(result).toEqual({ total: 3, succeeded: 3, failed: [] });
+  });
+
+  it('passes an explicit maxTokens through to every document, overriding sourceType defaults', async () => {
+    const documents = [
+      makeDocument({ sourceType: 'symptom', sourceId: 1 }),
+      makeDocument({ sourceType: 'treatment', sourceId: 2 }),
+    ];
+
+    readJournalDataMock.mockResolvedValue([{ id: 10 } as InjuryWithRelations]);
+    buildJournalDocumentsMock.mockReturnValue(documents);
+    embedAndStoreDocumentMock.mockResolvedValue(undefined);
+
+    await runIngestion(450);
+
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(1, documents[0], 450);
+    expect(embedAndStoreDocumentMock).toHaveBeenNthCalledWith(2, documents[1], 450);
   });
 
   it('continues processing after a single document fails, and reports the failure', async () => {


### PR DESCRIPTION
## Summary

Adds a chunk-size sweep tool so `DEFAULT_MAX_TOKENS` (300) is picked from
measurement instead of assumption, per #137.

- `evaluation/ai-system/chunk-size-sweep.ts` (`npm run eval:chunk-size`)
  re-ingests the seeded dev dataset and re-runs the AI-system eval harness
  at maxTokens = 150/300/450/600, printing a retrieval/citations/faithfulness
  comparison table. Guarded against running against the wrong database,
  mirroring `prisma/seed-dev.ts`.
- `CHUNK_MAX_TOKENS` is now a real, documented env var (`src/config/chunking.ts`)
  threaded through `ingestion-worker.ts` → `embed-and-store.ts` →
  `chunkDocument`, instead of an implicit function default.
- Added retry-with-backoff in `evaluation-runner.ts` for LLM-provider rate
  limits (429s), since a full sweep makes enough sequential calls to trip
  Groq's free-tier per-minute cap mid-run.
- Recorded the measured result in `docs/02-architecture.md` (D4): no
  candidate beat 300 on any metric, so the default is unchanged. Noted as
  pending re-verification against chunk overlap (#214, merged after the
  last measurement) — the re-run attempt hit Groq's *daily* token quota
  rather than a transient limit; will follow up once that resets.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (touched suites: `chunker`, `embed-and-store`,
      `ingestion-worker`, `chunking-config`, `evaluation-runner` — 42/42
      passing)
- [x] `npm run eval:chunk-size` run manually against a seeded dev DB +
      embedding service (see D4 note in `docs/02-architecture.md` for
      results)
- [ ] Re-run `npm run eval:chunk-size` once Groq's daily quota resets, to
      verify the result still holds with chunk overlap (#214) enabled

Fixes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URwBpgpUiimiWssCUjULef