### PR TITLE
fix: route unscoped questions to the matching injury before retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Set the following environment variables (see `.env.example` for a starting point
 | `PORT` | No | Defaults to 3000 |
 | `CHUNK_MAX_TOKENS` | No | Overrides max tokens per document chunk for every `sourceType` during ingestion, bypassing `SOURCE_TYPE_CHUNK_CONFIG`'s per-`sourceType` defaults (`src/ingestion/chunking/document-chunker.ts`). Leave unset to let each `sourceType` use its own configured default (currently 300 for all of them — see `docs/02-architecture.md` D4). |
 | `ALLOWED_ORIGIN` | No | Comma-separated list of allowed CORS origins. Unset reflects the request's own origin (no restriction) — low value until a real frontend is deployed at a known origin, at which point set this to lock CORS down. |
+| `INJURY_MATCH_AMBIGUITY_MARGIN` | No | Defaults to 0.03. Cosine-distance margin used by `src/retrieval/injury-router.ts` to decide which injuries an unscoped question (no `injuryId`) routes to — see `docs/02-architecture.md` D11. |
+| `MAX_MATCHED_INJURIES` | No | Defaults to 3. Caps how many near-tied injuries an unscoped question can route to (`src/retrieval/injury-router.ts`, D11). |
+| `INJURY_MATCH_FALLBACK_DISTANCE` | No | Defaults to 0.62. If no injury's summary chunk beats this cosine distance for an unscoped question, it's treated as not being about any one injury and routes to all of them instead of an arbitrary subset (`src/retrieval/injury-router.ts`, D11). |
 
 ### Database
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -842,13 +842,16 @@ quoted), what else was considered, whether it still holds, and whether it should
   service (not guessed): single-injury questions scored 0.32-0.56, broad/non-injury-specific
   questions scored 0.67-0.82 — the default sits in that gap. Only one user/two injuries were
   sampled, so this is real-but-thin, not evaluation-validated.
-- **KNOWN LIMITATION:** an injury's visibility to unscoped questions now depends entirely on its one
-  `sourceType: 'injury'` summary chunk having been successfully ingested — `ingestion-worker.ts`
-  embeds/stores each document independently and a single document's failure doesn't abort the run,
-  so a transient failure on just that one document (while the injury's other records succeed) would
-  make the injury invisible to unscoped questions until the next successful ingestion, even though
-  its explicit-`injuryId` dropdown path is unaffected. Not mitigated here; worth a targeted
-  ingestion-health check if it turns out to happen in practice.
+- **KNOWN LIMITATION (mitigated):** an injury's visibility to unscoped questions would otherwise
+  depend entirely on its one `sourceType: 'injury'` summary chunk having been successfully ingested
+  — `ingestion-worker.ts` embeds/stores each document independently and a single document's failure
+  doesn't abort the run, so a transient failure on just that one document (while the injury's other
+  records succeed) would make the injury invisible to unscoped questions until the next successful
+  ingestion. `routeInjuries()` now falls back to searching the user's chunks of *any* `sourceType`
+  when zero injury-summary chunks exist for them at all, so this degrades to the old (pre-#209)
+  unscoped-pooling behavior only in that narrow case, rather than returning nothing. Caught by CI:
+  `tests/integration/data-isolation.integration.test.ts` seeds chunks directly without an
+  injury-summary chunk and exercises exactly this path.
 - **SHOULD THIS BE REVISITED:** If a user's injury count grows large enough that
   `INJURY_CANDIDATE_LIMIT` (50, in `injury-router.ts`) stops being "effectively all of a user's
   injuries," or if evaluation data (once it has broad/multi-injury unscoped cases — see

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -219,11 +219,17 @@ flowchart TD
 
 > **Current status:** "Question Embedding" now uses the query-specific `/embed-query` endpoint as
 > of PR #55 (issue #37) — see §4.2's design-gap note for the merge-status caveat. "Metadata
-> Filtering" is `injuryId` only in production; `searchSimilarChunks` also accepts an optional
-> `sourceType` parameter, but no production caller passes one. `userId` and date-range filters are
-> not implemented (deliberately deferred pending evaluation data, per issue #35). There is no
+> Filtering" is `injuryId` and `userId` in production — `userId` filtering was added for
+> authorization (issue #95, see D10) and is now always passed by `rag-service.ts` as the
+> authenticated caller's id, not an optional filter. `searchSimilarChunks` also accepts an optional
+> `sourceType` parameter; no production caller passed one until #209 (D11), where injury-routing
+> queries `sourceType: 'injury'` chunks specifically. Date-range filtering is still not implemented
+> (deliberately deferred pending evaluation data, per issue #35). There is no
 > similarity threshold — "Top-k Relevant Chunks" really means "Top-k *Nearest* Chunks," which may
 > not be relevant at all if the journal has little or no ingested content for the question asked.
+> As of #209 (see D11), when `injuryId` is omitted this diagram's "Metadata Filtering" step is
+> preceded by an injury-routing step (`injury-router.ts`) that picks the `injuryId`(s) to filter on
+> from the question itself, instead of searching unfiltered across all of a user's injuries.
 
 ### Sequence Diagram
 
@@ -238,14 +244,14 @@ sequenceDiagram
     participant A as Embedding API
     participant E as EmbeddingService
     participant V as Vector storage
-    R->>S: Query, injuryId, limit
+    R->>S: Query, injuryId, userId, limit
     S->>C: embedQuery(query)
     C->>A: POST /embed-query
     A->>E: embed_query(text)
     E-->>A: Normalized query vector
     A-->>C: Embedding response
     C-->>S: Validated embedding
-    S->>V: searchSimilarChunks(vector, injuryId, limit)
+    S->>V: searchSimilarChunks(vector, injuryId, limit, sourceType, userId)
     V-->>S: Similar chunks
     S-->>R: Search results
 ```
@@ -790,3 +796,61 @@ quoted), what else was considered, whether it still holds, and whether it should
 - **SHOULD THIS BE REVISITED:** Only if the "existing Injury Journal application" assumption turns
   out to be wrong (e.g. no such external app actually exists yet) — not expected based on the
   current product description.
+
+### D11 — Unscoped queries route to an injury first, then reuse scoped retrieval (#209)
+
+- **DECISION:** When a question arrives without an `injuryId` (no dropdown selection), retrieval no
+  longer pools every injury's chunks into one top-k. Instead, `semantic-search.ts` first calls
+  `injury-router.ts`'s `routeInjuries()`, which compares the question's embedding against each
+  injury's own single `sourceType: 'injury'` summary chunk (one per injury, from
+  `document-builder.ts`) rather than the full per-record pool. Three outcomes:
+  1. A question with no injury-summary match closer than `INJURY_MATCH_FALLBACK_DISTANCE` (i.e. it
+     isn't clearly about any one injury — a broad "How am I doing overall?" question, see #210) —
+     routes to **all** of the user's injuries rather than an arbitrary subset.
+  2. Otherwise, the best match plus any near-tied injuries within `INJURY_MATCH_AMBIGUITY_MARGIN`,
+     capped at `MAX_MATCHED_INJURIES` (see `src/config/retrieval.ts` for all three constants).
+  3. A single clear winner, no ties — the common case.
+
+  The existing `injuryId`-scoped `searchSimilarChunks` call — already known correct — then runs once
+  per matched injury, each capped at a fair `Math.ceil(limit / matchedInjuryIds.length)` share so no
+  single matched injury's per-record chunks can crowd another out of the final result, and results
+  are merged/truncated to `limit`.
+- **RATIONALE:** Unscoped top-k across all injuries returned citations (and occasionally answer
+  content, #208) from clearly-unrelated injuries. A raw similarity/distance threshold on individual
+  record chunks was tried first and rejected on evidence: calibrated against the seeded dev dataset
+  with real embeddings, same-injury vs. other-injury record-level chunks were heavily interleaved
+  (record text is template-y — "On [date], the user received [X]. Provider: [Y]." — so topic isn't
+  well separated at that granularity), so no cutoff reliably separated them. Injury-level summary
+  chunks separate cleanly by contrast (correct injury was always closest, ~0.07–0.22 cosine-distance
+  gap to the next injury in spot checks), because each `Injury.name`/`bodyArea`/`description` is
+  distinct where individual event records aren't.
+- **RELATION TO D5:** D5 rejects adding a similarity threshold, hybrid search, or reranking *to the
+  per-record retrieval comparison itself* — that rejection stands, and this decision doesn't
+  reintroduce any of the three: no distance cutoff is applied to individual chunks, there's no
+  keyword/BM25 component, and the final chunk list isn't rescored/reordered by anything but the
+  existing `embedding <=> query` distance. This decision instead automates *which injury/injuries to
+  scope to* — the same choice a user already makes via the dropdown — using the same plain top-k
+  mechanism D5 keeps, just against a smaller, cleaner candidate set (one summary chunk per injury).
+- **ALTERNATIVES CONSIDERED:** A raw distance/similarity threshold on retrieved chunks (rejected,
+  see above — empirically doesn't separate injuries on this corpus). Filtering citations post-hoc by
+  answer-text content overlap (would fix citation noise but not #208's answer-text misattribution,
+  and adds a second heuristic instead of fixing retrieval at its source).
+- **CURRENT STATUS:** Implemented for #209. Also reduces (but is not a verified fix for) #208's
+  cross-injury misattribution risk, since both bugs share the same unscoped-pooling root cause —
+  #208 should still be verified independently. `INJURY_MATCH_FALLBACK_DISTANCE` (default 0.62) was
+  measured directly against the seeded dev dataset's real two-injury user via the live embedding
+  service (not guessed): single-injury questions scored 0.32-0.56, broad/non-injury-specific
+  questions scored 0.67-0.82 — the default sits in that gap. Only one user/two injuries were
+  sampled, so this is real-but-thin, not evaluation-validated.
+- **KNOWN LIMITATION:** an injury's visibility to unscoped questions now depends entirely on its one
+  `sourceType: 'injury'` summary chunk having been successfully ingested — `ingestion-worker.ts`
+  embeds/stores each document independently and a single document's failure doesn't abort the run,
+  so a transient failure on just that one document (while the injury's other records succeed) would
+  make the injury invisible to unscoped questions until the next successful ingestion, even though
+  its explicit-`injuryId` dropdown path is unaffected. Not mitigated here; worth a targeted
+  ingestion-health check if it turns out to happen in practice.
+- **SHOULD THIS BE REVISITED:** If a user's injury count grows large enough that
+  `INJURY_CANDIDATE_LIMIT` (50, in `injury-router.ts`) stops being "effectively all of a user's
+  injuries," or if evaluation data (once it has broad/multi-injury unscoped cases — see
+  `evaluation/ai-system/dataset.json`'s `rag-unscoped-multi-injury-001`) shows any of the three
+  `src/config/retrieval.ts` constants need recalibrating.

--- a/evaluation/ai-system/dataset.json
+++ b/evaluation/ai-system/dataset.json
@@ -245,5 +245,19 @@
         "sourceId": 2
       }
     ]
+  },
+  {
+    "id": "rag-unscoped-multi-injury-001",
+    "note": "Regression case for #209: userId 1 has two injuries (1: Lower back pain, 4: Right knee pain). No injuryId is given, so this exercises injury-routing (src/retrieval/injury-router.ts) rather than dropdown-scoped retrieval -- expectedSources must come only from injury 4's treatment, not injury 1's.",
+    "userId": 1,
+    "question": "What treatments have I tried for my knee?",
+    "expectedIntent": "rag",
+    "expectedBehavior": "answer_with_sources",
+    "expectedSources": [
+      {
+        "sourceType": "treatment",
+        "sourceId": 5
+      }
+    ]
   }
 ]

--- a/src/config/retrieval.ts
+++ b/src/config/retrieval.ts
@@ -1,0 +1,75 @@
+// Used by injury-router.ts to decide which injuries a question without an
+// explicit injuryId is actually about. Each injury has exactly one
+// sourceType:'injury' summary chunk (document-builder.ts); comparing the
+// question's embedding against just those chunks separates injuries far
+// more reliably than pooling every record across every injury (see #209).
+//
+// Empirically (against the seeded dev dataset's 3 distinct injuries), the
+// correct injury's summary chunk was always the closest match, with the
+// smallest observed gap to the next-closest injury being ~0.07 cosine
+// distance. The margin below is set comfortably under that so a clear
+// single-injury match doesn't accidentally pull in a second injury, while
+// still being loose enough to catch genuinely ambiguous/multi-injury
+// questions (near-tied distances).
+function parseNumberEnv(name: string, raw: string | undefined, fallback: number): number {
+  if (raw === undefined) {
+    return fallback;
+  }
+
+  if (raw.trim() === '') {
+    throw new Error(`Invalid ${name}: ${raw}`);
+  }
+
+  const parsed = Number(raw);
+
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${name}: ${raw}`);
+  }
+
+  return parsed;
+}
+
+const INJURY_MATCH_AMBIGUITY_MARGIN = parseNumberEnv(
+  'INJURY_MATCH_AMBIGUITY_MARGIN',
+  process.env.INJURY_MATCH_AMBIGUITY_MARGIN,
+  0.03,
+);
+
+const MAX_MATCHED_INJURIES = parseNumberEnv(
+  'MAX_MATCHED_INJURIES',
+  process.env.MAX_MATCHED_INJURIES,
+  3,
+);
+
+// A broad, non-injury-specific question (e.g. "How am I doing overall?")
+// doesn't resemble any single injury's name/bodyArea/description, so its
+// distance to every injury's summary chunk tends to be uniformly mediocre
+// rather than dominated by one clear winner or a small near-tied group —
+// the ambiguity margin above won't reliably catch this case (see #209/#210
+// discussion). If even the *closest* injury summary doesn't beat this
+// floor, treat the question as not being about any one injury in
+// particular and fall back to searching across all of the user's injuries,
+// rather than silently narrowing to an arbitrary subset.
+//
+// Measured directly against the seeded dev dataset's real user (userId 1,
+// two injuries: lower back / knee) via the live embedding service — not a
+// guess. Single-injury questions ("What treatments have I tried for my
+// knee?", "Why does my knee hurt?", etc.) scored a best injury-summary
+// distance of 0.32-0.56. Broad, non-injury-specific questions ("How am I
+// doing overall?", "Summarize my recovery progress", "List all my
+// treatments") scored 0.67-0.82. This default (0.62) sits in the gap
+// between those two clusters. Only 2 injuries and a handful of questions
+// were sampled, so this is a real-but-thin calibration, not an
+// evaluation-validated cutoff — recalibrate if the evaluation dataset gains
+// broad/multi-injury cases and this stops separating them correctly.
+const INJURY_MATCH_FALLBACK_DISTANCE = parseNumberEnv(
+  'INJURY_MATCH_FALLBACK_DISTANCE',
+  process.env.INJURY_MATCH_FALLBACK_DISTANCE,
+  0.62,
+);
+
+export {
+  INJURY_MATCH_AMBIGUITY_MARGIN,
+  MAX_MATCHED_INJURIES,
+  INJURY_MATCH_FALLBACK_DISTANCE,
+};

--- a/src/retrieval/injury-router.ts
+++ b/src/retrieval/injury-router.ts
@@ -30,7 +30,24 @@ export async function routeInjuries(
   );
 
   if (injuryChunks.length === 0) {
-    return [];
+    // This user has no sourceType:'injury' summary chunk to route on at
+    // all — e.g. an injury summary specifically failed to ingest while its
+    // other records succeeded (see the D11 known-limitation note), or a
+    // caller stored chunks directly without going through the full
+    // ingestion pipeline. Don't return nothing: fall back to searching
+    // across whatever injuries the user does have chunks for, so an
+    // unscoped question still finds real data instead of silently coming
+    // up empty.
+    const anyChunks = await searchSimilarChunks(
+      embedding,
+      undefined,
+      INJURY_CANDIDATE_LIMIT,
+      undefined,
+      userId,
+      requestId,
+    );
+
+    return [...new Set(anyChunks.map((chunk) => chunk.injuryId))];
   }
 
   const bestDistance = injuryChunks[0].distance;

--- a/src/retrieval/injury-router.ts
+++ b/src/retrieval/injury-router.ts
@@ -1,0 +1,62 @@
+import { searchSimilarChunks } from '../embeddings/vector-storage.js';
+import {
+  INJURY_MATCH_AMBIGUITY_MARGIN,
+  MAX_MATCHED_INJURIES,
+  INJURY_MATCH_FALLBACK_DISTANCE,
+} from '../config/retrieval.js';
+
+// A user's total injury count is always small (a personal journal, not a
+// multi-tenant catalog), so this is effectively "all of this user's
+// injuries" rather than a real top-k cutoff.
+const INJURY_CANDIDATE_LIMIT = 50;
+
+// Determines which injury (or injuries, if the match is ambiguous) an
+// unscoped question is actually about, by comparing the question's
+// embedding against each injury's own summary chunk (sourceType: 'injury')
+// rather than the full pool of per-record chunks. See #209 and
+// src/config/retrieval.ts for why.
+export async function routeInjuries(
+  embedding: number[],
+  userId: number,
+  requestId?: string,
+): Promise<number[]> {
+  const injuryChunks = await searchSimilarChunks(
+    embedding,
+    undefined,
+    INJURY_CANDIDATE_LIMIT,
+    'injury',
+    userId,
+    requestId,
+  );
+
+  if (injuryChunks.length === 0) {
+    return [];
+  }
+
+  const bestDistance = injuryChunks[0].distance;
+
+  // No injury is a clear match for this question (e.g. a broad "How am I
+  // doing overall?" question, see #210) — searching only the near-tied
+  // top few would silently drop injuries the question is arguably about
+  // just as much as the ones that happened to be included. Search across
+  // all of the user's injuries instead.
+  if (bestDistance > INJURY_MATCH_FALLBACK_DISTANCE) {
+    return injuryChunks.map((chunk) => chunk.injuryId);
+  }
+
+  const selected: number[] = [injuryChunks[0].injuryId];
+
+  for (
+    let i = 1;
+    i < injuryChunks.length && selected.length < MAX_MATCHED_INJURIES;
+    i++
+  ) {
+    if (injuryChunks[i].distance - bestDistance > INJURY_MATCH_AMBIGUITY_MARGIN) {
+      break;
+    }
+
+    selected.push(injuryChunks[i].injuryId);
+  }
+
+  return selected;
+}

--- a/src/retrieval/semantic-search.ts
+++ b/src/retrieval/semantic-search.ts
@@ -1,5 +1,6 @@
 import { embedQuery } from '../embeddings/embedding-client.js';
 import { searchSimilarChunks } from '../embeddings/vector-storage.js';
+import { routeInjuries } from './injury-router.js';
 
 export async function semanticSearch(
   query: string,
@@ -10,5 +11,45 @@ export async function semanticSearch(
 ) {
   const result = await embedQuery(query, requestId);
 
-  return searchSimilarChunks(result.embedding, injuryId, limit, undefined, userId, requestId);
+  if (injuryId !== undefined) {
+    return searchSimilarChunks(result.embedding, injuryId, limit, undefined, userId, requestId);
+  }
+
+  // No injury was picked (e.g. no dropdown selection). Pooling every
+  // injury's chunks into one top-k pulls in clearly-unrelated injuries
+  // (#209) — route to the injury/injuries the question is actually about
+  // first, then reuse the same scoped search used by the explicit-injuryId
+  // path above, which is already known to retrieve correctly.
+  const matchedInjuryIds = await routeInjuries(result.embedding, userId, requestId);
+
+  if (matchedInjuryIds.length === 0) {
+    return [];
+  }
+
+  // Give every matched injury a fair shot at the final result instead of
+  // querying each for the full `limit` and letting per-record distance
+  // (already shown unreliable at cross-injury comparisons — see #209/D11)
+  // decide how many slots each injury gets. Capping each injury's own
+  // query at its fair share means no single injury can crowd out another
+  // injury that was judged equally relevant by the (trustworthy)
+  // injury-level routing step above.
+  const perInjuryLimit = Math.max(1, Math.ceil(limit / matchedInjuryIds.length));
+
+  const perInjuryResults = await Promise.all(
+    matchedInjuryIds.map((matchedInjuryId) =>
+      searchSimilarChunks(
+        result.embedding,
+        matchedInjuryId,
+        perInjuryLimit,
+        undefined,
+        userId,
+        requestId,
+      ),
+    ),
+  );
+
+  return perInjuryResults
+    .flat()
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, limit);
 }

--- a/tests/injury-router.test.ts
+++ b/tests/injury-router.test.ts
@@ -1,0 +1,92 @@
+import { jest } from '@jest/globals';
+
+const searchSimilarChunksMock = jest.fn();
+
+jest.unstable_mockModule('../src/embeddings/vector-storage.js', () => ({
+  searchSimilarChunks: searchSimilarChunksMock,
+}));
+
+const { routeInjuries } = await import('../src/retrieval/injury-router.js');
+
+function injuryChunk(injuryId: number, distance: number) {
+  return {
+    id: injuryId,
+    injuryId,
+    userId: 1,
+    sourceType: 'injury',
+    sourceId: injuryId,
+    chunkIndex: 0,
+    content: `Injury summary ${injuryId}`,
+    metadata: null,
+    distance,
+  };
+}
+
+describe('routeInjuries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('searches only sourceType:injury chunks for this user', async () => {
+    searchSimilarChunksMock.mockResolvedValue([injuryChunk(1, 0.1)]);
+
+    await routeInjuries([0.1, 0.2], 7, 'req-1');
+
+    expect(searchSimilarChunksMock).toHaveBeenCalledWith(
+      [0.1, 0.2],
+      undefined,
+      50,
+      'injury',
+      7,
+      'req-1',
+    );
+  });
+
+  it('returns just the best match when it clearly beats the rest', async () => {
+    searchSimilarChunksMock.mockResolvedValue([
+      injuryChunk(3, 0.46),
+      injuryChunk(1, 0.68),
+      injuryChunk(2, 0.69),
+    ]);
+
+    const result = await routeInjuries([0.1, 0.2], 1);
+
+    expect(result).toEqual([3]);
+  });
+
+  it('includes near-tied injuries within the ambiguity margin, up to the cap', async () => {
+    searchSimilarChunksMock.mockResolvedValue([
+      injuryChunk(1, 0.5),
+      injuryChunk(2, 0.51),
+      injuryChunk(3, 0.52),
+      injuryChunk(4, 0.9),
+    ]);
+
+    const result = await routeInjuries([0.1, 0.2], 1);
+
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it('returns an empty array when the user has no injuries', async () => {
+    searchSimilarChunksMock.mockResolvedValue([]);
+
+    const result = await routeInjuries([0.1, 0.2], 1);
+
+    expect(result).toEqual([]);
+  });
+
+  it('falls back to every injury when nothing is a clear match (#210)', async () => {
+    searchSimilarChunksMock.mockResolvedValue([
+      injuryChunk(1, 0.8),
+      injuryChunk(2, 0.85),
+      injuryChunk(3, 0.9),
+      injuryChunk(4, 0.95),
+    ]);
+
+    const result = await routeInjuries([0.1, 0.2], 1);
+
+    // Beyond MAX_MATCHED_INJURIES (3) and not near-tied — the fallback
+    // should still return all 4, not silently drop the 4th.
+    expect(result).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/tests/injury-router.test.ts
+++ b/tests/injury-router.test.ts
@@ -67,12 +67,41 @@ describe('routeInjuries', () => {
     expect(result).toEqual([1, 2, 3]);
   });
 
-  it('returns an empty array when the user has no injuries', async () => {
+  it('returns an empty array when the user has no chunks at all', async () => {
     searchSimilarChunksMock.mockResolvedValue([]);
 
     const result = await routeInjuries([0.1, 0.2], 1);
 
     expect(result).toEqual([]);
+  });
+
+  it('falls back to searching any sourceType when the user has chunks but no injury-summary chunk', async () => {
+    searchSimilarChunksMock.mockImplementation(
+      async (_embedding, _injuryId, _limit, sourceType: string | undefined) => {
+        if (sourceType === 'injury') {
+          return [];
+        }
+
+        return [
+          { id: 1, injuryId: 5, sourceType: 'treatment', sourceId: 1, distance: 0.2 },
+          { id: 2, injuryId: 5, sourceType: 'symptom', sourceId: 2, distance: 0.3 },
+        ];
+      },
+    );
+
+    const result = await routeInjuries([0.1, 0.2], 1);
+
+    expect(searchSimilarChunksMock).toHaveBeenCalledTimes(2);
+    expect(searchSimilarChunksMock).toHaveBeenNthCalledWith(
+      2,
+      [0.1, 0.2],
+      undefined,
+      50,
+      undefined,
+      1,
+      undefined,
+    );
+    expect(result).toEqual([5]);
   });
 
   it('falls back to every injury when nothing is a clear match (#210)', async () => {

--- a/tests/integration/rag-pipeline.integration.test.ts
+++ b/tests/integration/rag-pipeline.integration.test.ts
@@ -111,6 +111,62 @@ describe('RAG pipeline integration', () => {
     expect(mockGenerateAnswer).toHaveBeenCalledTimes(1);
   });
 
+  it('routes an unscoped question to the matching injury and excludes unrelated injuries from citations (#209)', async () => {
+    const otherInjury = await prisma.injury.create({
+      data: {
+        name: 'Unrelated shoulder injury',
+        bodyArea: 'shoulder',
+        startDate: new Date(),
+        userId,
+      },
+    });
+
+    try {
+      // The injury's own summary chunk is what routing compares the
+      // question against — put it close to the question embedding so this
+      // injury is the one selected.
+      await storeDocumentChunk(
+        injuryId,
+        userId,
+        'injury',
+        injuryId,
+        0,
+        'Injury: RAG Pipeline Test. Body area: hip.',
+        vectorWith(1, 0, 0),
+      );
+
+      // The unrelated injury's chunks sit far away in embedding space so
+      // they lose the routing step entirely.
+      await storeDocumentChunk(
+        otherInjury.id,
+        userId,
+        'treatment',
+        1,
+        0,
+        'Physical therapy for the shoulder.',
+        vectorWith(0, 1, 0),
+      );
+
+      const result = await answerQuestion(
+        'What treatments did I have?',
+        undefined,
+        userId,
+        5,
+      );
+
+      expect(result.chunks.length).toBeGreaterThan(0);
+      expect(result.chunks.every((chunk) => chunk.injuryId === injuryId)).toBe(true);
+
+      expect(result.citations.length).toBeGreaterThan(0);
+      expect(result.citations.every((c) => c.sourceType !== 'treatment' || c.sourceId !== 1)).toBe(
+        true,
+      );
+    } finally {
+      await prisma.documentChunk.deleteMany({ where: { injuryId: otherInjury.id } });
+      await prisma.injury.delete({ where: { id: otherInjury.id } });
+    }
+  });
+
   it('blocks diagnosis requests before retrieval or LLM generation', async () => {
     const result = await answerQuestion('Do I have a fracture?', injuryId, userId);
 

--- a/tests/semantic-search.test.ts
+++ b/tests/semantic-search.test.ts
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 
 const embedQueryMock = jest.fn();
 const searchSimilarChunksMock = jest.fn();
+const routeInjuriesMock = jest.fn();
 
 jest.unstable_mockModule('../src/embeddings/embedding-client.js', () => ({
   embedQuery: embedQueryMock,
@@ -11,6 +12,10 @@ jest.unstable_mockModule('../src/embeddings/vector-storage.js', () => ({
   searchSimilarChunks: searchSimilarChunksMock,
 }));
 
+jest.unstable_mockModule('../src/retrieval/injury-router.js', () => ({
+  routeInjuries: routeInjuriesMock,
+}));
+
 const { semanticSearch } = await import('../src/retrieval/semantic-search.js');
 
 describe('semanticSearch', () => {
@@ -18,7 +23,7 @@ describe('semanticSearch', () => {
     jest.clearAllMocks();
   });
 
-  it('embeds the query and searches using the resulting embedding', async () => {
+  it('routes an unscoped query to the matched injury and searches within it', async () => {
     const embedding = [0.1, 0.2, 0.3];
 
     embedQueryMock.mockResolvedValue({
@@ -29,9 +34,12 @@ describe('semanticSearch', () => {
       version: 'test-version',
     });
 
+    routeInjuriesMock.mockResolvedValue([9]);
+
     const chunks = [
       {
         id: 1,
+        injuryId: 9,
         content: 'Lower back pain after sitting.',
         distance: 0.1,
       },
@@ -50,9 +58,11 @@ describe('semanticSearch', () => {
       undefined,
     );
 
+    expect(routeInjuriesMock).toHaveBeenCalledWith(embedding, 1, undefined);
+
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       embedding,
-      undefined,
+      9,
       5,
       undefined,
       1,
@@ -62,7 +72,7 @@ describe('semanticSearch', () => {
     expect(result).toEqual(chunks);
   });
 
-  it('passes a custom result limit to vector search', async () => {
+  it('merges, sorts, and truncates results when the question matches multiple injuries', async () => {
     embedQueryMock.mockResolvedValue({
       embedding: [0.1, 0.2],
       model: 'test-model',
@@ -71,18 +81,85 @@ describe('semanticSearch', () => {
       version: 'test-version',
     });
 
+    routeInjuriesMock.mockResolvedValue([1, 2]);
+
+    searchSimilarChunksMock.mockImplementation(async (_embedding, matchedInjuryId: number) => {
+      if (matchedInjuryId === 1) {
+        return [
+          { id: 10, injuryId: 1, distance: 0.5 },
+          { id: 11, injuryId: 1, distance: 0.1 },
+        ];
+      }
+
+      return [{ id: 20, injuryId: 2, distance: 0.3 }];
+    });
+
+    const result = await semanticSearch('a broad question', undefined, 1, 2);
+
+    expect(result).toEqual([
+      { id: 11, injuryId: 1, distance: 0.1 },
+      { id: 20, injuryId: 2, distance: 0.3 },
+    ]);
+  });
+
+  it('apportions the limit fairly across matched injuries so one cannot crowd out another', async () => {
+    embedQueryMock.mockResolvedValue({
+      embedding: [0.1, 0.2],
+      model: 'test-model',
+      modelVersion: 'v1',
+      dimension: 2,
+      version: 'test-version',
+    });
+
+    routeInjuriesMock.mockResolvedValue([1, 2, 3]);
+
     searchSimilarChunksMock.mockResolvedValue([]);
 
-    await semanticSearch('lower back pain', undefined, 1, 10);
+    await semanticSearch('a broad question', undefined, 1, 5);
 
+    // limit=5 across 3 matched injuries: ceil(5/3) = 2 per injury.
+    expect(searchSimilarChunksMock).toHaveBeenCalledTimes(3);
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
-      undefined,
-      10,
+      1,
+      2,
       undefined,
       1,
       undefined,
     );
+    expect(searchSimilarChunksMock).toHaveBeenCalledWith(
+      [0.1, 0.2],
+      2,
+      2,
+      undefined,
+      1,
+      undefined,
+    );
+    expect(searchSimilarChunksMock).toHaveBeenCalledWith(
+      [0.1, 0.2],
+      3,
+      2,
+      undefined,
+      1,
+      undefined,
+    );
+  });
+
+  it('returns no chunks when the user has no matching injuries', async () => {
+    embedQueryMock.mockResolvedValue({
+      embedding: [0.1, 0.2],
+      model: 'test-model',
+      modelVersion: 'v1',
+      dimension: 2,
+      version: 'test-version',
+    });
+
+    routeInjuriesMock.mockResolvedValue([]);
+
+    const result = await semanticSearch('lower back pain', undefined, 1);
+
+    expect(result).toEqual([]);
+    expect(searchSimilarChunksMock).not.toHaveBeenCalled();
   });
 
   it('passes injuryId to vector search when provided', async () => {
@@ -130,6 +207,22 @@ describe('semanticSearch', () => {
     searchSimilarChunksMock.mockRejectedValue(
       new Error('database unavailable'),
     );
+
+    await expect(semanticSearch('lower back pain', 42, 1)).rejects.toThrow(
+      'database unavailable',
+    );
+  });
+
+  it('propagates injury-routing errors for unscoped queries', async () => {
+    embedQueryMock.mockResolvedValue({
+      embedding: [0.1, 0.2],
+      model: 'test-model',
+      modelVersion: 'v1',
+      dimension: 2,
+      version: 'test-version',
+    });
+
+    routeInjuriesMock.mockRejectedValue(new Error('database unavailable'));
 
     await expect(semanticSearch('lower back pain', undefined, 1)).rejects.toThrow(
       'database unavailable',


### PR DESCRIPTION
## Summary
- Unscoped questions (no `injuryId`) previously pooled every injury's chunks into one top-k search,
  so citations/context could include content from injuries clearly unrelated to the question.
- A raw distance threshold was tried first and rejected on evidence — record-level chunks (symptom/
  treatment/visit text) don't separate cleanly by injury, calibrated against the real seeded dev data.
- Fix: unscoped questions now route to the matching injury/injuries first (via each injury's own
  summary chunk, `src/retrieval/injury-router.ts`), then reuse the existing `injuryId`-scoped
  retrieval path already known correct. Falls back to searching all injuries when no injury is a
  clear match (e.g. broad "how am I doing overall" questions — see #210), and apportions results
  fairly across matched injuries so one can't crowd out another.
- See `docs/02-architecture.md` D11 for the full design rationale, including its relationship to D5
  (no threshold/hybrid/rerank on record-level retrieval — unchanged).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` — 278/320 pass; the 9 failing suites are pre-existing local test-DB/embedding-service
      environment gaps unrelated to this change (verified identical against a clean `main` baseline)
- [x] New unit tests: `tests/injury-router.test.ts`, extended `tests/semantic-search.test.ts`
- [x] New integration regression test in `tests/integration/rag-pipeline.integration.test.ts`
      (blocked from running locally by the same DB gap above — will run in CI)
- [x] Verified routing behavior directly against the real dev DB (two real injuries under one user):
      knee question → only knee's `treatment #5` cited; back question → only back's records cited
- [x] Added `rag-unscoped-multi-injury-001` to `evaluation/ai-system/dataset.json` — first unscoped,
      multi-injury case in the harness

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URwBpgpUiimiWssCUjULef