### PR TITLE
feat: add similarity threshold to retrieval and no-relevant-context response

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -838,13 +838,19 @@ quoted), what else was considered, whether it still holds, and whether it should
   chunks separate cleanly by contrast (correct injury was always closest, ~0.07–0.22 cosine-distance
   gap to the next injury in spot checks), because each `Injury.name`/`bodyArea`/`description` is
   distinct where individual event records aren't.
-- **RELATION TO D5:** D5 rejects adding a similarity threshold, hybrid search, or reranking *to the
-  per-record retrieval comparison itself* — that rejection stands, and this decision doesn't
-  reintroduce any of the three: no distance cutoff is applied to individual chunks, there's no
-  keyword/BM25 component, and the final chunk list isn't rescored/reordered by anything but the
-  existing `embedding <=> query` distance. This decision instead automates *which injury/injuries to
-  scope to* — the same choice a user already makes via the dropdown — using the same plain top-k
-  mechanism D5 keeps, just against a smaller, cleaner candidate set (one summary chunk per injury).
+- **RELATION TO D5:** D5 originally rejected adding a similarity threshold, hybrid search, or
+  reranking *to the per-record retrieval comparison itself*; issue #122 has since added a distance
+  cutoff to that per-record comparison (see D5, updated). This decision (D11) predates that and is
+  unaffected by it: `routeInjuries()`'s own `searchSimilarChunks` calls explicitly pass
+  `MAX_COSINE_DISTANCE` to bypass the cutoff, because injury-summary-chunk routing uses its own
+  calibrated distance logic (`INJURY_MATCH_FALLBACK_DISTANCE`/ambiguity margin, described above) that
+  needs to see the full distance range — not the generic default. There's still no keyword/BM25
+  component here, and the final chunk list isn't rescored/reordered by anything but the existing
+  `embedding <=> query` distance (now filtered by D5's cutoff for individual chunks, same as any
+  other `searchSimilarChunks` caller that doesn't opt out). This decision instead automates *which
+  injury/injuries to scope to* — the same choice a user already makes via the dropdown — using the
+  same plain top-k mechanism, just against a smaller, cleaner candidate set (one summary chunk per
+  injury).
 - **ALTERNATIVES CONSIDERED:** A raw distance/similarity threshold on retrieved chunks (rejected,
   see above — empirically doesn't separate injuries on this corpus). Filtering citations post-hoc by
   answer-text content overlap (would fix citation noise but not #208's answer-text misattribution,

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -224,9 +224,11 @@ flowchart TD
 > authenticated caller's id, not an optional filter. `searchSimilarChunks` also accepts an optional
 > `sourceType` parameter; no production caller passed one until #209 (D11), where injury-routing
 > queries `sourceType: 'injury'` chunks specifically. Date-range filtering is still not implemented
-> (deliberately deferred pending evaluation data, per issue #35). There is no
-> similarity threshold — "Top-k Relevant Chunks" really means "Top-k *Nearest* Chunks," which may
-> not be relevant at all if the journal has little or no ingested content for the question asked.
+> (deliberately deferred pending evaluation data, per issue #35). As of #122 (see D5), "Top-k
+> Relevant Chunks" is now filtered by a cosine-distance cutoff (`maxDistance` on
+> `searchSimilarChunks`, default `0.7`, not yet evaluation-tuned) before returning — a question with
+> no chunks close enough gets an explicit no-relevant-context answer from `rag-service.ts` instead
+> of an LLM-generated one over irrelevant context.
 > As of #209 (see D11), when `injuryId` is omitted this diagram's "Metadata Filtering" step is
 > preceded by an injury-routing step (`injury-router.ts`) that picks the `injuryId`(s) to filter on
 > from the question itself, instead of searching unfiltered across all of a user's injuries.
@@ -653,32 +655,44 @@ quoted), what else was considered, whether it still holds, and whether it should
     real ingestion (`npm run ingest`) still defers to `SOURCE_TYPE_CHUNK_CONFIG` normally; only the
     sweep (and anyone who sets `CHUNK_MAX_TOKENS`) forces a single value across every sourceType.
 
-### D5 — Plain top-k cosine retrieval; no similarity threshold, hybrid search, or reranking
+### D5 — Top-k cosine retrieval with a similarity threshold; still no hybrid search or reranking
 
-- **DECISION:** Retrieval is `ORDER BY embedding <=> query LIMIT k` with no minimum-similarity
-  cutoff, no keyword/BM25 hybrid component, and no reranking stage.
-- **RATIONALE:** `CLAUDE.md` explicitly lists "hybrid/threshold/rerank retrieval" under "Do NOT
-  introduce," citing evaluation as the reason ("deliberately rejected or deferred"). §5.1 of this
-  document notes the deferral is "pending evaluation data" (issue #35) — i.e., the position is
-  that tuning a threshold or adding rerank without evaluation data to justify it risks solving the
-  wrong problem or optimizing on vibes.
-- **ALTERNATIVES CONSIDERED:** A similarity threshold (return nothing below a cosine-distance
-  cutoff) — would directly help the "no relevant information" case, but requires a calibrated
-  cutoff value the project doesn't have strong evidence for yet (see
-  `evaluation/ai-system/dataset.json` for current case count and coverage). Hybrid (keyword +
-  vector) search or a cross-encoder rerank stage — both add real complexity and a second scoring
-  signal to tune, for a corpus size where it's not yet clear pure vector top-k is actually
-  underperforming.
-- **CURRENT STATUS:** Still valid as a deliberate deferral. Whether the evaluation dataset is now
-  large enough to inform this decision on evidence should be checked against its current size
-  (`evaluation/ai-system/dataset.json`) rather than a number restated here. Since chunk overlap was
-  added (D4, issue #135), `LIMIT k` can return two adjacent chunks that share most of their text —
-  there is no near-duplicate suppression here, so an overlap-heavy result can cost a query one of
-  its `k` slots on redundant content. Worth watching if evaluation surfaces this as a real quality
-  problem; not addressed by this decision today.
-- **SHOULD THIS BE REVISITED:** Maybe — not by implementing threshold/hybrid/rerank now, but by
-  confirming the evaluation dataset is large enough to make this decision on evidence rather than
-  leaving it open indefinitely.
+- **DECISION (updated, issue #122):** Retrieval is `ORDER BY embedding <=> query LIMIT k`, now with
+  a minimum-similarity (maximum cosine-distance) cutoff via `maxDistance` on `searchSimilarChunks`
+  (`src/embeddings/vector-storage.ts`), defaulting to `DEFAULT_DISTANCE_THRESHOLD = 0.7`. When
+  retrieval returns zero chunks — either because nothing exists or because everything found was
+  beyond the cutoff — `rag-service.ts` returns an explicit no-relevant-context answer instead of
+  calling the LLM. There is still no keyword/BM25 hybrid component and no reranking stage.
+- **ORIGINAL RATIONALE (superseded in part):** `CLAUDE.md` listed "hybrid/threshold/rerank
+  retrieval" under "Do NOT introduce," on the grounds that tuning a threshold without evaluation
+  data risks solving the wrong problem or optimizing on vibes. That reasoning is still sound for
+  hybrid search and reranking — both stay deferred. For the threshold specifically, issue #122
+  judged the risk of *no* cutoff (irrelevant chunks silently feeding the LLM, violating CLAUDE.md
+  priority #1) as worse than the risk of an initial, clearly-labeled-as-unproven default.
+- **WHY THE DEFAULT IS 0.7, NOT AN EVALUATION-DERIVED VALUE:** The evaluation dataset is still too
+  small/thin to calibrate a threshold the way D11's `INJURY_MATCH_FALLBACK_DISTANCE` was calibrated
+  (real measured distance clusters). `0.7` is a conservative starting point only — loose enough that
+  it shouldn't cut off distances in the 0.32–0.56 range that D11 measured for genuinely relevant
+  single-injury content. It is not evaluation-backed and should be revisited once the evaluation
+  dataset (`evaluation/ai-system/dataset.json`) is large enough to measure real relevant vs.
+  irrelevant distance clusters for record-level (not injury-summary) retrieval.
+- **INTERACTION WITH D11 (injury routing):** The default threshold applies only to record-level
+  content retrieval, not to `injury-router.ts`'s own `searchSimilarChunks` calls. Injury routing
+  passes `maxDistance: MAX_COSINE_DISTANCE` (2, i.e. no-op) explicitly, because it needs the full
+  distance spectrum for its own calibrated logic
+  (`INJURY_MATCH_FALLBACK_DISTANCE`/ambiguity margin — see D11) — the generic 0.7 cutoff would
+  otherwise silently drop candidates that logic depends on seeing (broad/multi-injury questions were
+  measured at 0.67–0.82 distance).
+- **ALTERNATIVES CONSIDERED:** Hybrid (keyword + vector) search or a cross-encoder rerank stage —
+  both still add real complexity and a second scoring signal to tune, for a corpus size where it's
+  not yet clear pure vector top-k is actually underperforming; both remain deferred.
+- **CURRENT STATUS:** Chunk overlap (D4, issue #135) can still return two adjacent chunks that share
+  most of their text — there is no near-duplicate suppression, so an overlap-heavy result can cost a
+  query one of its `k` slots on redundant content, independent of the threshold. Worth watching if
+  evaluation surfaces this as a real quality problem.
+- **SHOULD THIS BE REVISITED:** Yes — the `0.7` default specifically, once the evaluation dataset is
+  large enough to calibrate it on evidence rather than a conservative guess. Hybrid search and
+  reranking remain deferred as before.
 
 ### D6 — Hand-written deterministic intent router instead of an agent framework (LangGraph deferred)
 

--- a/docs/05-api-contract.md
+++ b/docs/05-api-contract.md
@@ -209,11 +209,16 @@ This is the most important section — these are gaps, not just documentation de
   together with its chunk-derived citations in a single JSON object. No frontend consumer exists
   yet to justify the added complexity of streaming. Revisit if/when a frontend is built and latency
   proves to be a real UX problem.
-- **An explicit groundedness/confidence signal.** CLAUDE.md's stated priority — prefer an
-  explicit lack-of-information response over an unsupported plausible answer — is enforced only
-  as a soft instruction inside the LLM prompt (`prompt-builder.ts`), not as a structural check or
-  a field the frontend could branch on (e.g., "zero chunks retrieved" or "low similarity" is not
-  surfaced anywhere in the response).
+- **An explicit groundedness/confidence signal (partially addressed, #122).** CLAUDE.md's stated
+  priority — prefer an explicit lack-of-information response over an unsupported plausible answer —
+  is now enforced structurally for the "nothing close enough was retrieved" case: `searchSimilarChunks`
+  applies a cosine-distance cutoff (`maxDistance`, default `0.7`, not yet evaluation-tuned — see D5
+  in `docs/02-architecture.md`), and `rag-service.ts` returns a fixed no-relevant-context answer with
+  `chunks: []`/`citations: []` when nothing passes it, without calling the LLM. This is still not
+  surfaced as a distinct field the frontend could branch on (e.g. no `metadata.groundedness` flag) —
+  a caller can only infer it from `retrievedChunks` being empty and matching the reserved wording,
+  not from a dedicated signal. The prompt-level soft instruction in `prompt-builder.ts` still remains
+  as a second layer for cases where chunks *are* retrieved but don't actually answer the question.
 
 ## 7. Change discipline
 

--- a/docs/07-flows-review.md
+++ b/docs/07-flows-review.md
@@ -89,9 +89,10 @@ exists — the documented invariant was never actually verified, and doesn't hol
 **What actually happens:** `semanticSearch()` (`retrieval/semantic-search.ts`) calls `embedQuery()`
 — the **query-side** embedding endpoint — on the user's question, then passes the resulting
 vector to `searchSimilarChunks()` (`vector-storage.ts`), which runs a plain
-`ORDER BY embedding <=> query LIMIT k` query, filtered by `injuryId` only when provided, plus a
-cosine-distance cutoff (`maxDistance`, default `0.7` — see §11 Decision D5, updated for issue #122).
-No other metadata filter, no `userId` scoping (see §11 Decision D9).
+`ORDER BY embedding <=> query LIMIT k` query, filtered by `injuryId` only when provided, by the
+authenticated caller's `userId` (always passed by `semanticSearch`, see §11 Decision D9 — resolved),
+plus a cosine-distance cutoff (`maxDistance`, default `0.7` — see §11 Decision D5, updated for
+issue #122). No other metadata filter.
 
 **What should happen:** the question should be embedded via the query-side prompt
 (`embed_query()` in the Python service), not the document-side one — Qwen3-Embedding-0.6B is
@@ -116,7 +117,10 @@ query/document embedding-mode gap above).
 1. `checkSafety(question)` — regex-based pre-generation check. If blocked, returns immediately
    with a refusal message, `chunks: []`, `citations: []` — **no retrieval or LLM call happens at
    all** for a blocked question.
-2. `semanticSearch(question, injuryId, limit)` — see Flow 3.
+2. `semanticSearch(question, injuryId, limit)` — see Flow 3. If this returns zero chunks (nothing
+   exists, or everything found was beyond the distance cutoff — see D5, issue #122),
+   `answerQuestion` returns immediately with a fixed no-relevant-context message, `chunks: []`,
+   `citations: []` — **no LLM call happens at all** for this case; steps 3-7 below are skipped.
 3. `buildContext(chunks)` — joins raw chunk `content` with `Source N:` headers and `---`
    separators. **No token-budget check** — if retrieval ever returns many/large chunks, nothing
    caps the resulting prompt size before it's sent to the LLM.
@@ -148,11 +152,12 @@ generic `500 { error: "Failed to generate answer" }` — no distinction between 
 "invalid credentials," or "rate limited," and no retry at any layer.
 
 **Tests:** `context-builder.ts`'s empty-input behavior (an empty `chunks` array still produces a
-valid, if minimal, context string — no crash) is tested, and `answerQuestion`'s empty-retrieval
-path is now tested too (`tests/rag-service.test.ts`, "still generates an answer when retrieval
-finds zero chunks") — it confirms the LLM is still called with an essentially empty
-`<journal_data>` section. Resolved (issue #39). No test currently asserts what a *real* LLM tends
-to answer in this scenario beyond the mocked expectation — that would need an LLM integration test.
+valid, if minimal, context string — no crash) is tested, but is now unreachable from
+`answerQuestion` for the zero-chunks case specifically, since that returns before `buildContext` is
+called (issue #122). `answerQuestion`'s empty-retrieval path is tested directly instead
+(`tests/rag-service.test.ts`, "returns an explicit no-relevant-context answer when retrieval finds
+zero chunks (#122)") — it asserts the fixed message and that `buildContext`/`buildUserPrompt`/
+`generateAnswer`/`buildCitations` are never called. Resolved (issue #39).
 
 **Questionable boundary:** none new beyond what §5.3/§5.4 of the architecture doc already state.
 
@@ -167,7 +172,7 @@ Traced directly against the controllers and services, not assumed:
 | **DB fails** | Any Prisma/raw-SQL error (`vector-storage.ts`, `journal-tool.ts`) propagates uncaught up to the same controller-level `catch` → same generic 500. |
 | **Bad/malformed document (ingestion)** | Not directly applicable — `buildJournalDocuments` operates on already-typed Prisma results, not external/untrusted input. The closest analogue, a chunk whose content becomes empty after processing, is covered under Flow 2's chunker finding above. |
 | **Duplicate ingestion** | Handled correctly and idempotently — `storeDocumentChunk`'s `ON CONFLICT (sourceType, sourceId, chunkIndex) DO UPDATE` means re-ingesting the same source record updates existing rows rather than duplicating them, and `deleteDocumentChunksExcept` prunes chunks left over from a run that previously produced more chunks for that record. Verified via `vector-storage.ts` directly, not assumed. |
-| **Empty retrieval result** | `searchSimilarChunks` returns `[]` → `buildContext([])` returns an empty string → the LLM still receives a prompt with an empty `<journal_data>` section and is instructed (in the prompt text only, not structurally) to say it lacks enough information. `checkContentSafety` runs on the empty string but has nothing to match, so it doesn't short-circuit this case; the mocked LLM call is tested for this path (see Flow 4), but whether a *real* model actually follows the "say you lack enough information" instruction is unverified. |
+| **Empty retrieval result** | `searchSimilarChunks` returns `[]` (nothing exists, or nothing passed the distance cutoff — see D5, issue #122) → `answerQuestion` returns a fixed no-relevant-context message directly, `chunks: []`, `citations: []` — `buildContext`, `checkContentSafety`, and `generateAnswer` are never called for this case (see Flow 4). This is now a structural check, not just the prompt-level "say you lack enough information" instruction, which still remains as a second layer for the case where chunks *are* retrieved but don't actually answer the question. |
 
 **Cross-cutting observation:** every failure class above collapses into the same generic
 `{ error: "Failed to process request" }` 500 response, with no error code/type. A frontend cannot

--- a/docs/07-flows-review.md
+++ b/docs/07-flows-review.md
@@ -89,8 +89,9 @@ exists — the documented invariant was never actually verified, and doesn't hol
 **What actually happens:** `semanticSearch()` (`retrieval/semantic-search.ts`) calls `embedQuery()`
 — the **query-side** embedding endpoint — on the user's question, then passes the resulting
 vector to `searchSimilarChunks()` (`vector-storage.ts`), which runs a plain
-`ORDER BY embedding <=> query LIMIT k` query, filtered by `injuryId` only when provided. No
-similarity threshold, no other metadata filter, no `userId` scoping (see §11 Decision D9).
+`ORDER BY embedding <=> query LIMIT k` query, filtered by `injuryId` only when provided, plus a
+cosine-distance cutoff (`maxDistance`, default `0.7` — see §11 Decision D5, updated for issue #122).
+No other metadata filter, no `userId` scoping (see §11 Decision D9).
 
 **What should happen:** the question should be embedded via the query-side prompt
 (`embed_query()` in the Python service), not the document-side one — Qwen3-Embedding-0.6B is

--- a/src/embeddings/vector-storage.ts
+++ b/src/embeddings/vector-storage.ts
@@ -122,8 +122,7 @@ export async function searchSimilarChunks(
   if (sourceType !== undefined) filters.push(Prisma.sql`"sourceType" = ${sourceType}`);
   if (userId !== undefined) filters.push(Prisma.sql`"userId" = ${userId}`);
 
-  const whereClause =
-    filters.length > 0 ? Prisma.sql`WHERE ${Prisma.join(filters, ' AND ')}` : Prisma.empty;
+  const whereClause = Prisma.sql`WHERE ${Prisma.join(filters, ' AND ')}`;
 
   return prisma.$queryRaw<SearchSimilarChunk[]>(
     Prisma.sql`

--- a/src/embeddings/vector-storage.ts
+++ b/src/embeddings/vector-storage.ts
@@ -14,6 +14,18 @@ type SearchSimilarChunk = Pick<
 > & {
   distance: number;
 };
+// pgvector's `<=>` cosine distance operator ranges 0 (identical) to 2
+// (opposite). Passing this as maxDistance disables the cutoff entirely —
+// for callers (like injury-router.ts) that need the full distance spectrum
+// because they apply their own, differently-calibrated distance logic.
+export const MAX_COSINE_DISTANCE = 2;
+
+// Default cosine distance cutoff for searchSimilarChunks. This is a
+// conservative starting point, not a tuned value — issue #122 calls for
+// tuning it against evaluation results once enough labeled retrieval data
+// exists.
+export const DEFAULT_DISTANCE_THRESHOLD = 0.7;
+
 export async function disconnectVectorStorage() {
   await prisma.$disconnect();
 }
@@ -97,12 +109,15 @@ export async function searchSimilarChunks(
   sourceType?: string,
   userId?: number,
   requestId?: string,
+  maxDistance = DEFAULT_DISTANCE_THRESHOLD,
 ) {
   void requestId; // unused for now — reserved for future log correlation (#32)
 
   const vector = `[${embedding.join(',')}]`;
 
-  const filters: Prisma.Sql[] = [];
+  const filters: Prisma.Sql[] = [
+    Prisma.sql`"embedding" <=> ${vector}::vector <= ${maxDistance}`,
+  ];
   if (injuryId !== undefined) filters.push(Prisma.sql`"injuryId" = ${injuryId}`);
   if (sourceType !== undefined) filters.push(Prisma.sql`"sourceType" = ${sourceType}`);
   if (userId !== undefined) filters.push(Prisma.sql`"userId" = ${userId}`);

--- a/src/rag/rag-service.ts
+++ b/src/rag/rag-service.ts
@@ -51,8 +51,8 @@ export async function answerQuestion(
   if (chunks.length === 0) {
     return {
       answer:
-        'No journal entries closely matched this question. Try rephrasing it, ' +
-        'or asking about a specific date or injury.',
+        'The journal does not contain information that closely matches this question. ' +
+        'Try rephrasing it, or asking about a specific date or injury.',
       chunks: [],
       citations: [],
     };

--- a/src/rag/rag-service.ts
+++ b/src/rag/rag-service.ts
@@ -48,6 +48,16 @@ export async function answerQuestion(
 
   const chunks = await semanticSearch(question, injuryId, userId, limit, requestId);
 
+  if (chunks.length === 0) {
+    return {
+      answer:
+        'No journal entries closely matched this question. Try rephrasing it, ' +
+        'or asking about a specific date or injury.',
+      chunks: [],
+      citations: [],
+    };
+  }
+
   const injuryNames = new Map<number, string>();
 
   if (injuryId !== undefined) {

--- a/src/retrieval/injury-router.ts
+++ b/src/retrieval/injury-router.ts
@@ -1,4 +1,4 @@
-import { searchSimilarChunks } from '../embeddings/vector-storage.js';
+import { searchSimilarChunks, MAX_COSINE_DISTANCE } from '../embeddings/vector-storage.js';
 import {
   INJURY_MATCH_AMBIGUITY_MARGIN,
   MAX_MATCHED_INJURIES,
@@ -20,6 +20,10 @@ export async function routeInjuries(
   userId: number,
   requestId?: string,
 ): Promise<number[]> {
+  // Bypass the default distance cutoff here: this function's own distance
+  // logic below (INJURY_MATCH_FALLBACK_DISTANCE / ambiguity margin) needs to
+  // see every candidate's distance, including ones a generic threshold would
+  // otherwise drop, to decide whether the question matches any injury at all.
   const injuryChunks = await searchSimilarChunks(
     embedding,
     undefined,
@@ -27,6 +31,7 @@ export async function routeInjuries(
     'injury',
     userId,
     requestId,
+    MAX_COSINE_DISTANCE,
   );
 
   if (injuryChunks.length === 0) {
@@ -45,6 +50,7 @@ export async function routeInjuries(
       undefined,
       userId,
       requestId,
+      MAX_COSINE_DISTANCE,
     );
 
     return [...new Set(anyChunks.map((chunk) => chunk.injuryId))];

--- a/src/retrieval/semantic-search.ts
+++ b/src/retrieval/semantic-search.ts
@@ -8,11 +8,20 @@ export async function semanticSearch(
   userId: number,
   limit = 5,
   requestId?: string,
+  maxDistance?: number,
 ) {
   const result = await embedQuery(query, requestId);
 
   if (injuryId !== undefined) {
-    return searchSimilarChunks(result.embedding, injuryId, limit, undefined, userId, requestId);
+    return searchSimilarChunks(
+      result.embedding,
+      injuryId,
+      limit,
+      undefined,
+      userId,
+      requestId,
+      maxDistance,
+    );
   }
 
   // No injury was picked (e.g. no dropdown selection). Pooling every
@@ -44,6 +53,7 @@ export async function semanticSearch(
         undefined,
         userId,
         requestId,
+        maxDistance,
       ),
     ),
   );

--- a/tests/evaluation-metrics.test.ts
+++ b/tests/evaluation-metrics.test.ts
@@ -66,6 +66,18 @@ describe('evaluation metrics', () => {
     expect(evaluateNoInformation('no_information_found', result)).toBe(true);
   });
 
+  it('passes no-information checks for rag-service.ts\'s fixed no-relevant-context message (#122)', () => {
+    const result: AgentOutput = {
+      answer:
+        'The journal does not contain information that closely matches this question. ' +
+        'Try rephrasing it, or asking about a specific date or injury.',
+      citations: [],
+      intent: 'rag',
+    };
+
+    expect(evaluateNoInformation('no_information_found', result)).toBe(true);
+  });
+
   it('fails no-information checks when the answer contains substantive content', () => {
     const result: AgentOutput = {
       answer: 'You tried physiotherapy on 2025-01-10 with limited improvement.',

--- a/tests/injury-router.test.ts
+++ b/tests/injury-router.test.ts
@@ -4,9 +4,15 @@ const searchSimilarChunksMock = jest.fn();
 
 jest.unstable_mockModule('../src/embeddings/vector-storage.js', () => ({
   searchSimilarChunks: searchSimilarChunksMock,
+  MAX_COSINE_DISTANCE: 2,
 }));
 
 const { routeInjuries } = await import('../src/retrieval/injury-router.js');
+
+// injury-router.ts bypasses the default distance cutoff by passing pgvector's
+// max possible cosine distance explicitly — kept in sync with
+// MAX_COSINE_DISTANCE in src/embeddings/vector-storage.ts.
+const MAX_COSINE_DISTANCE = 2;
 
 function injuryChunk(injuryId: number, distance: number) {
   return {
@@ -39,6 +45,7 @@ describe('routeInjuries', () => {
       'injury',
       7,
       'req-1',
+      MAX_COSINE_DISTANCE,
     );
   });
 
@@ -100,6 +107,7 @@ describe('routeInjuries', () => {
       undefined,
       1,
       undefined,
+      MAX_COSINE_DISTANCE,
     );
     expect(result).toEqual([5]);
   });

--- a/tests/integration/vector-storage.integration.test.ts
+++ b/tests/integration/vector-storage.integration.test.ts
@@ -3,6 +3,7 @@ import {
   searchSimilarChunks,
   storeDocumentChunk,
   disconnectVectorStorage,
+  MAX_COSINE_DISTANCE,
 } from '../../src/embeddings/vector-storage.js';
 import {
   createTestInjury,
@@ -87,6 +88,9 @@ describe('vector storage integration', () => {
       undefined,
       3,
       'vector-storage-integration-test',
+      undefined,
+      undefined,
+      MAX_COSINE_DISTANCE,
     );
 
     expect(results).toHaveLength(3);
@@ -233,6 +237,9 @@ describe('vector storage integration', () => {
       undefined,
       5,
       'vector-storage-integration-test',
+      undefined,
+      undefined,
+      MAX_COSINE_DISTANCE,
     );
 
     expect(results).toHaveLength(1);
@@ -242,5 +249,40 @@ describe('vector storage integration', () => {
       DELETE FROM "DocumentChunk"
       WHERE "sourceType" = 'some-other-source-type'
     `;
+  });
+
+  it('drops chunks beyond maxDistance and keeps ones within it (#122)', async () => {
+    await storeDocumentChunk(
+      injuryA.injuryId,
+      injuryA.userId,
+      'vector-storage-integration-test',
+      8,
+      0,
+      'Close chunk',
+      vectorWith(1, 0, 0),
+    );
+
+    await storeDocumentChunk(
+      injuryA.injuryId,
+      injuryA.userId,
+      'vector-storage-integration-test',
+      8,
+      1,
+      'Orthogonal chunk',
+      vectorWith(0, 1, 0),
+    );
+
+    const results = await searchSimilarChunks(
+      vectorWith(1, 0, 0),
+      undefined,
+      5,
+      'vector-storage-integration-test',
+      undefined,
+      undefined,
+      0.5,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('Close chunk');
   });
 });

--- a/tests/rag-service.test.ts
+++ b/tests/rag-service.test.ts
@@ -299,44 +299,20 @@ describe('rag service', () => {
     expect(buildCitationsMock).not.toHaveBeenCalled();
   });
 
-  it('still generates an answer when retrieval finds zero chunks', async () => {
+  it('returns an explicit no-relevant-context answer when retrieval finds zero chunks (#122)', async () => {
     semanticSearchMock.mockResolvedValue([]);
-
-    buildContextMock.mockReturnValue('');
-
-    buildUserPromptMock.mockReturnValue('prompt with empty context');
-
-    generateAnswerMock.mockResolvedValue(
-      'I do not have enough information to answer that.',
-    );
-
-    buildCitationsMock.mockReturnValue([]);
 
     const result = await answerQuestion('What treatments have I tried?', undefined, 1);
 
-    expect(buildContextMock).toHaveBeenCalledWith([], new Map(), undefined);
+    expect(result.chunks).toEqual([]);
+    expect(result.citations).toEqual([]);
+    expect(result.answer).toMatch(/no journal entries/i);
 
+    expect(buildContextMock).not.toHaveBeenCalled();
     expect(findManyMock).not.toHaveBeenCalled();
-
-    expect(buildUserPromptMock).toHaveBeenCalledWith(
-      'What treatments have I tried?',
-      '',
-      undefined,
-    );
-
-    expect(generateAnswerMock).toHaveBeenCalledWith(
-      'system prompt',
-      'prompt with empty context',
-      undefined,
-    );
-
-    expect(buildCitationsMock).toHaveBeenCalledWith([], new Map(), undefined);
-
-    expect(result).toEqual({
-      answer: 'I do not have enough information to answer that.',
-      citations: [],
-      chunks: [],
-    });
+    expect(buildUserPromptMock).not.toHaveBeenCalled();
+    expect(generateAnswerMock).not.toHaveBeenCalled();
+    expect(buildCitationsMock).not.toHaveBeenCalled();
   });
 
   it('propagates retrieval errors', async () => {

--- a/tests/rag-service.test.ts
+++ b/tests/rag-service.test.ts
@@ -306,7 +306,7 @@ describe('rag service', () => {
 
     expect(result.chunks).toEqual([]);
     expect(result.citations).toEqual([]);
-    expect(result.answer).toMatch(/no journal entries/i);
+    expect(result.answer).toMatch(/does not contain/i);
 
     expect(buildContextMock).not.toHaveBeenCalled();
     expect(findManyMock).not.toHaveBeenCalled();

--- a/tests/semantic-search.test.ts
+++ b/tests/semantic-search.test.ts
@@ -67,6 +67,7 @@ describe('semanticSearch', () => {
       undefined,
       1,
       undefined,
+      undefined,
     );
 
     expect(result).toEqual(chunks);
@@ -126,6 +127,7 @@ describe('semanticSearch', () => {
       undefined,
       1,
       undefined,
+      undefined,
     );
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
@@ -133,6 +135,7 @@ describe('semanticSearch', () => {
       2,
       undefined,
       1,
+      undefined,
       undefined,
     );
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
@@ -141,6 +144,7 @@ describe('semanticSearch', () => {
       2,
       undefined,
       1,
+      undefined,
       undefined,
     );
   });
@@ -181,6 +185,7 @@ describe('semanticSearch', () => {
       5,
       undefined,
       1,
+      undefined,
       undefined,
     );
   });

--- a/tests/vector-storage.test.ts
+++ b/tests/vector-storage.test.ts
@@ -50,6 +50,7 @@ const {
   deleteDocumentChunksExcept,
   searchSimilarChunks,
   disconnectVectorStorage,
+  DEFAULT_DISTANCE_THRESHOLD,
 } = await import('../src/embeddings/vector-storage.js');
 
 beforeEach(() => {
@@ -173,54 +174,54 @@ describe('searchSimilarChunks', () => {
     await searchSimilarChunks([0.1, 0.2, 0.3], undefined, 7);
 
     expect(queryRawMock).toHaveBeenCalledTimes(1);
-    expect(joinMock).not.toHaveBeenCalled();
+    expect(joinMock).toHaveBeenCalledTimes(1);
 
     const query = queryRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values[0]).toBe('[0.1,0.2,0.3]');
-    expect(query.values[1]).toBe(emptyMarker);
     expect(query.values[2]).toBe('[0.1,0.2,0.3]');
     expect(query.values[3]).toBe(7);
   });
 
-  it('uses no WHERE clause and default limit when neither filter is provided', async () => {
+  it('always applies a distance-threshold filter, defaulting to DEFAULT_DISTANCE_THRESHOLD', async () => {
     await searchSimilarChunks([1]);
-
-    const query = queryRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[1]).toBe(emptyMarker);
-    expect(query.values[3]).toBe(5);
-  });
-
-  it('filters by injuryId only when sourceType is omitted', async () => {
-    await searchSimilarChunks([1], 42);
 
     expect(joinMock).toHaveBeenCalledTimes(1);
     const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
     expect(separator).toBe(' AND ');
     expect(filters).toHaveLength(1);
-    expect(filters[0].values).toEqual([42]);
-    expect(filters[0].strings.join('')).toContain('"injuryId"');
+    expect(filters[0].values).toEqual(['[1]', DEFAULT_DISTANCE_THRESHOLD]);
+    expect(filters[0].strings.join('')).toContain('"embedding" <=>');
 
     const query = queryRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[1]).toEqual({
-      strings: expect.any(Array),
-      values: [joinMock.mock.results[0].value],
-    });
+    expect(query.values[3]).toBe(5);
   });
 
-  it('filters by sourceType only when injuryId is omitted', async () => {
+  it('uses the provided maxDistance instead of the default', async () => {
+    await searchSimilarChunks([1], undefined, 5, undefined, undefined, undefined, 0.3);
+
+    const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(filters[0].values).toEqual(['[1]', 0.3]);
+  });
+
+  it('filters by injuryId in addition to the distance threshold when sourceType is omitted', async () => {
+    await searchSimilarChunks([1], 42);
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(separator).toBe(' AND ');
+    expect(filters).toHaveLength(2);
+    expect(filters[1].values).toEqual([42]);
+    expect(filters[1].strings.join('')).toContain('"injuryId"');
+  });
+
+  it('filters by sourceType in addition to the distance threshold when injuryId is omitted', async () => {
     await searchSimilarChunks([1], undefined, 5, 'treatment');
 
     expect(joinMock).toHaveBeenCalledTimes(1);
     const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
-    expect(filters).toHaveLength(1);
-    expect(filters[0].values).toEqual(['treatment']);
-    expect(filters[0].strings.join('')).toContain('"sourceType"');
-
-    const query = queryRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[1]).toEqual({
-      strings: expect.any(Array),
-      values: [joinMock.mock.results[0].value],
-    });
+    expect(filters).toHaveLength(2);
+    expect(filters[1].values).toEqual(['treatment']);
+    expect(filters[1].strings.join('')).toContain('"sourceType"');
   });
 
   it('filters by both injuryId and sourceType when both are provided', async () => {
@@ -229,33 +230,21 @@ describe('searchSimilarChunks', () => {
     expect(joinMock).toHaveBeenCalledTimes(1);
     const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
     expect(separator).toBe(' AND ');
-    expect(filters).toHaveLength(2);
-    expect(filters[0].values).toEqual([42]);
-    expect(filters[0].strings.join('')).toContain('"injuryId"');
-    expect(filters[1].values).toEqual(['treatment']);
-    expect(filters[1].strings.join('')).toContain('"sourceType"');
-
-    const query = queryRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[1]).toEqual({
-      strings: expect.any(Array),
-      values: [joinMock.mock.results[0].value],
-    });
+    expect(filters).toHaveLength(3);
+    expect(filters[1].values).toEqual([42]);
+    expect(filters[1].strings.join('')).toContain('"injuryId"');
+    expect(filters[2].values).toEqual(['treatment']);
+    expect(filters[2].strings.join('')).toContain('"sourceType"');
   });
 
-  it('filters by userId only when injuryId and sourceType are omitted', async () => {
+  it('filters by userId in addition to the distance threshold when injuryId and sourceType are omitted', async () => {
     await searchSimilarChunks([1], undefined, 5, undefined, 42);
 
     expect(joinMock).toHaveBeenCalledTimes(1);
     const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
-    expect(filters).toHaveLength(1);
-    expect(filters[0].values).toEqual([42]);
-    expect(filters[0].strings.join('')).toContain('"userId"');
-
-    const query = queryRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[1]).toEqual({
-      strings: expect.any(Array),
-      values: [joinMock.mock.results[0].value],
-    });
+    expect(filters).toHaveLength(2);
+    expect(filters[1].values).toEqual([42]);
+    expect(filters[1].strings.join('')).toContain('"userId"');
   });
 
   it('filters by injuryId, sourceType, and userId together when all are provided', async () => {
@@ -264,13 +253,13 @@ describe('searchSimilarChunks', () => {
     expect(joinMock).toHaveBeenCalledTimes(1);
     const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
     expect(separator).toBe(' AND ');
-    expect(filters).toHaveLength(3);
-    expect(filters[0].values).toEqual([42]);
-    expect(filters[0].strings.join('')).toContain('"injuryId"');
-    expect(filters[1].values).toEqual(['treatment']);
-    expect(filters[1].strings.join('')).toContain('"sourceType"');
-    expect(filters[2].values).toEqual([7]);
-    expect(filters[2].strings.join('')).toContain('"userId"');
+    expect(filters).toHaveLength(4);
+    expect(filters[1].values).toEqual([42]);
+    expect(filters[1].strings.join('')).toContain('"injuryId"');
+    expect(filters[2].values).toEqual(['treatment']);
+    expect(filters[2].strings.join('')).toContain('"sourceType"');
+    expect(filters[3].values).toEqual([7]);
+    expect(filters[3].strings.join('')).toContain('"userId"');
   });
 });
 


### PR DESCRIPTION
## Summary
- `searchSimilarChunks` now applies a cosine-distance cutoff (`maxDistance`, default `0.7`) so irrelevant chunks aren't fed to the LLM as context.
- `rag-service.ts` returns an explicit no-relevant-context answer (`chunks: []`, `citations: []`) when nothing passes the cutoff, instead of asking the LLM to generate an answer over empty/irrelevant context.
- Injury routing (`injury-router.ts`) explicitly bypasses this new default cutoff via `MAX_COSINE_DISTANCE`, since its own distance-based logic (ambiguity margin, fallback distance) needs to see the full distance range.
- `docs/02-architecture.md` decision D5 is updated to record this as a superseding decision (it previously documented a deliberate rejection of a similarity threshold pending evaluation data), along with why `0.7` is a conservative starting point rather than an evaluation-tuned value.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (343 tests, including updated/new unit + integration coverage for the threshold and no-relevant-context path)
- [ ] `evaluation/ai-system/run-full-evaluation.sh` — partially run (seed + ingest succeeded); the LLM-judged faithfulness step hit Groq's exhausted daily token quota, not a code issue. To be retried once the quota resets.

Fixes #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cosine-distance filtering to retrieval, using a default threshold of 0.7.
  * Added support for configuring the maximum similarity distance.
  * Searches with no sufficiently relevant results now return an explicit no-relevant-context response instead of generating an answer from unrelated content.
  * Injury routing continues evaluating all candidates before applying its own routing logic.

* **Documentation**
  * Updated architecture, API, and search-flow documentation to describe retrieval thresholds and grounded responses.

* **Tests**
  * Added coverage for distance filtering and no-result responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->