### PR TITLE
fix: count field-alone overlap drops in processFields

### DIFF
--- a/src/ingestion/chunking/document-chunker.ts
+++ b/src/ingestion/chunking/document-chunker.ts
@@ -371,9 +371,8 @@ function processSentences(
 // no field boundary exists (the common case for terse records with a
 // single label), defers straight to processSentences — identical to the
 // pre-field-splitting behavior. Mirrors the paragraph-level fit/seed
-// pattern in chunkDocument one level down. Only propagates droppedOverlap
-// from the sentence/word levels below — the field-alone fallback here has
-// the same silent-drop pattern but isn't counted yet; tracked in #221.
+// pattern in chunkDocument one level down, including its own field-alone
+// drop count alongside what's propagated up from the sentence/word levels.
 function processFields(
   chunks: JournalDocument[],
   document: JournalDocument,
@@ -413,13 +412,16 @@ function processFields(
     }
 
     if (countTokens(field) <= effectiveMaxTokens) {
-      // Not counted: see #221 — the field-alone drop case isn't wired into
-      // droppedOverlapCount yet.
-      const seeded = fieldOverlapSeed
-        ? `${fieldOverlapSeed} ${field}`
-        : field;
-      currentChunk =
-        countTokens(seeded) <= effectiveMaxTokens ? seeded : field;
+      const result = seedOrFallback(
+        fieldOverlapSeed,
+        field,
+        ' ',
+        effectiveMaxTokens,
+      );
+      if (result.dropped) {
+        droppedOverlap++;
+      }
+      currentChunk = result.chunk;
       continue;
     }
 

--- a/tests/chunker.test.ts
+++ b/tests/chunker.test.ts
@@ -521,6 +521,42 @@ describe('Document Chunker', () => {
       }
     });
 
+    it('logs a dropped-overlap boundary at a field-alone fallback (#221)', () => {
+      // maxTokens: 21 -> effectiveMaxTokens 17. Two labeled fields, each of
+      // which fits effectiveMaxTokens alone (12 and 10 tokens) but not
+      // together (21 tokens combined), forcing a chunk save between them.
+      // With overlapTokens: 10 the carried-forward seed (10 tokens) plus
+      // the second field (10 tokens) exceeds 17, so the drop happens in
+      // processFields' own field-alone fallback — unlike the #216 test
+      // above, this field never falls through to processSentences.
+      const twoFieldDocument: JournalDocument = {
+        content:
+          'Doctor: Dr. Alvarez ran a full physical exam today. ' +
+          'Clinic: Downtown Physical Therapy building on Main.',
+        metadata: {
+          userId: 1,
+          injuryId: 1,
+          sourceType: 'medical_visit',
+          sourceId: 6,
+          date: new Date('2025-01-15'),
+        },
+      };
+
+      const debugSpy = jest
+        .spyOn(console, 'debug')
+        .mockImplementation(() => {});
+
+      try {
+        chunkDocument(twoFieldDocument, 21, 10);
+
+        expect(debugSpy).toHaveBeenCalledWith(
+          expect.stringContaining('dropped overlap'),
+        );
+      } finally {
+        debugSpy.mockRestore();
+      }
+    });
+
     it('splits real document-builder.ts output on its own field labels', () => {
       // Runs actual buildJournalDocuments() output through the chunker,
       // rather than a hand-typed literal, so a label rename in


### PR DESCRIPTION
## Summary
- `processFields`'s field-alone fallback had the same silent-overlap-drop
  pattern #216/#219 fixed for the paragraph/sentence/word levels, but it
  landed after #219 and was left uncounted (marked with a "see #221"
  comment in the code).
- Now uses the existing `seedOrFallback` helper, same as the other three
  call sites, so a dropped seed at a field boundary is counted into
  `droppedOverlapCount` and shows up in the existing debug log.
- No change to chunk output content — verified by the full existing test
  suite passing unchanged, plus a new test isolating this specific branch.

Fixes #221

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (347/347 passing, including a new test in
      `tests/chunker.test.ts` covering the field-alone drop case)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document chunking to correctly track and report dropped overlap boundaries when field-level fallback is required.
  * Preserved field content when overlap context exceeds the available chunk size.

* **Tests**
  * Added coverage for overlap-boundary reporting during field-based chunk splitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->