### PR TITLE
fix: keep adjacent near-duplicate chunks instead of dropping them

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -627,9 +627,13 @@ quoted), what else was considered, whether it still holds, and whether it should
   switching to fixed-size windows, preserving the boundary-respecting behavior above.
 - **CURRENT STATUS:** Still valid and well-tested (`document-chunker.ts` plus
   `docs/03-chunker-architecture.md`'s test list covers boundary cases directly, including overlap).
-  Overlap means adjacent chunks can now return near-duplicate text from retrieval (see D5) — there
-  is no dedup/diversity step downstream, which is an accepted tradeoff for now given the small
-  corpus size, not a bug.
+  Overlap means adjacent chunks can return near-duplicate text from retrieval (see D5); as of #215,
+  `semanticSearch` (`src/retrieval/semantic-search.ts`) over-fetches and, when it finds a run of
+  mutually-adjacent chunks (`sourceType`+`sourceId`+`chunkIndex` within 1 of each other — a pair or
+  longer), still returns every chunk in that run — it just doesn't let the run consume more than
+  one of the `limit` distinct-source slots. Nothing is ever dropped: given this is healthcare
+  journal content, losing a chunk's unique content to save a result slot was judged the wrong
+  tradeoff, so the result can exceed `limit` instead (bounded by the over-fetch pool size, see D5).
 - **SHOULD THIS BE REVISITED:** No.
 - **`DEFAULT_MAX_TOKENS` (300) is now measured, not assumed (#137):** `evaluation/ai-system/chunk-size-sweep.ts`
   (`npm run eval:chunk-size`) re-ingests the seeded dev dataset and re-runs the eval harness at
@@ -686,13 +690,30 @@ quoted), what else was considered, whether it still holds, and whether it should
 - **ALTERNATIVES CONSIDERED:** Hybrid (keyword + vector) search or a cross-encoder rerank stage —
   both still add real complexity and a second scoring signal to tune, for a corpus size where it's
   not yet clear pure vector top-k is actually underperforming; both remain deferred.
-- **CURRENT STATUS:** Chunk overlap (D4, issue #135) can still return two adjacent chunks that share
-  most of their text — there is no near-duplicate suppression, so an overlap-heavy result can cost a
-  query one of its `k` slots on redundant content, independent of the threshold. Worth watching if
-  evaluation surfaces this as a real quality problem.
+- **CURRENT STATUS:** Chunk overlap (D4, issue #135) could return two adjacent chunks that share
+  most of their text, costing a query one of its `k` slots on redundant content, independent of the
+  threshold above. Addressed by #215, deliberately *without* dropping content (given this is
+  healthcare journal data): `semanticSearch` over-fetches (`limit * 2`) and, when it finds a run of
+  mutually-adjacent chunks from the same source, keeps every chunk in the run but only counts the
+  run once toward `limit` — so the result can exceed `limit` rather than ever discarding a chunk's
+  unique content. This is retrieval-side near-duplicate handling, not the threshold/hybrid/rerank
+  additions this decision otherwise covers.
+  Known limitations:
+  - The `limit * 2` over-fetch window is fixed, not adaptive — if most of the over-fetched
+    candidates for a query are mutually adjacent, the result can still land below `limit` distinct
+    sources even though more exist further down the true ranking. No fallback re-query exists for
+    this today; treat it as expected behavior, not a bug, if it shows up in evaluation results.
+  - Because a whole contiguous run collapses into one slot regardless of its length, the result
+    size is bounded by the over-fetch pool size (`limit * 2` per injury query), not by `limit` —
+    a query whose entire over-fetched pool is one long run returns all of it. For the unscoped
+    (multi-injury) path, this also means the #209/D11 "fair share" apportionment is fair in slot
+    count but not necessarily in raw content volume: one matched injury contributing one long run
+    can supply disproportionately more prompt content than another injury's single, non-adjacent
+    chunk, even though both used one "slot."
 - **SHOULD THIS BE REVISITED:** Yes — the `0.7` default specifically, once the evaluation dataset is
   large enough to calibrate it on evidence rather than a conservative guess. Hybrid search and
-  reranking remain deferred as before.
+  reranking remain deferred as before. The near-duplicate handling above is not pending revisit —
+  it's implemented; only its two known limitations remain open watch items.
 
 ### D6 — Hand-written deterministic intent router instead of an agent framework (LangGraph deferred)
 

--- a/src/rag/rag-service.ts
+++ b/src/rag/rag-service.ts
@@ -10,6 +10,10 @@ import {
 } from '../safety/safety-service.js';
 import { prisma } from '../lib/prisma.js';
 
+// `limit` is a target number of distinct sources, not a hard cap on chunks
+// used for grounding — see `semanticSearch`. More chunks than `limit` can be
+// retrieved (and end up in `context`/`citations`) when adjacent near-duplicate
+// chunks are found, since none of their content is ever dropped (#215).
 export async function answerQuestion(
   question: string,
   injuryId: number | undefined,

--- a/src/retrieval/semantic-search.ts
+++ b/src/retrieval/semantic-search.ts
@@ -2,6 +2,58 @@ import { embedQuery } from '../embeddings/embedding-client.js';
 import { searchSimilarChunks } from '../embeddings/vector-storage.js';
 import { routeInjuries } from './injury-router.js';
 
+// Adjacent chunks from the same source can share most of their text once
+// chunk overlap is involved (#135) — over-fetch so an adjacent duplicate
+// doesn't cost the query one of its `limit` distinct sources (#215).
+const OVERFETCH_FACTOR = 2;
+
+interface DedupableChunk {
+  sourceType: string;
+  sourceId: number;
+  chunkIndex: number;
+  distance: number;
+}
+
+// Never drops a chunk — healthcare journal content must not be silently
+// discarded just because it sits next to a near-duplicate. Instead, an
+// adjacent chunk (same source, chunkIndex within 1) is still returned but
+// doesn't count toward `limit`, so the result can exceed `limit` rather
+// than lose a distinct source to make room for a near-duplicate. This
+// extends transitively: a whole run of mutually-adjacent chunks (e.g.
+// chunkIndex 2, 3, 4 in sequence) collapses into a single distinct slot,
+// however long the run is, and every chunk in it is still returned. In the
+// worst case (the entire over-fetched pool forms one contiguous run), the
+// result size is bounded by the pool size (`limit * OVERFETCH_FACTOR`),
+// not by `limit` — see `semanticSearch`'s `limit` param below.
+function capToDistinctLimit<T extends DedupableChunk>(chunks: T[], limit: number): T[] {
+  const sorted = [...chunks].sort((a, b) => a.distance - b.distance);
+  const kept: T[] = [];
+  let distinctCount = 0;
+
+  for (const chunk of sorted) {
+    if (distinctCount >= limit) break;
+
+    const isAdjacentToKept = kept.some(
+      (keptChunk) =>
+        keptChunk.sourceType === chunk.sourceType &&
+        keptChunk.sourceId === chunk.sourceId &&
+        Math.abs(keptChunk.chunkIndex - chunk.chunkIndex) <= 1,
+    );
+
+    kept.push(chunk);
+
+    if (!isAdjacentToKept) {
+      distinctCount += 1;
+    }
+  }
+
+  return kept;
+}
+
+// `limit` is a target number of *distinct* sources, not a hard cap on chunks
+// returned — see `capToDistinctLimit`. A query with adjacent near-duplicate
+// chunks can return more than `limit` chunks (bounded by `limit *
+// OVERFETCH_FACTOR`), never fewer than what's genuinely available.
 export async function semanticSearch(
   query: string,
   injuryId: number | undefined,
@@ -13,15 +65,17 @@ export async function semanticSearch(
   const result = await embedQuery(query, requestId);
 
   if (injuryId !== undefined) {
-    return searchSimilarChunks(
+    const chunks = await searchSimilarChunks(
       result.embedding,
       injuryId,
-      limit,
+      limit * OVERFETCH_FACTOR,
       undefined,
       userId,
       requestId,
       maxDistance,
     );
+
+    return capToDistinctLimit(chunks, limit);
   }
 
   // No injury was picked (e.g. no dropdown selection). Pooling every
@@ -42,6 +96,13 @@ export async function semanticSearch(
   // query at its fair share means no single injury can crowd out another
   // injury that was judged equally relevant by the (trustworthy)
   // injury-level routing step above.
+  //
+  // Caveat (#215): this apportions distinct *slots* fairly, not raw content
+  // volume. If one injury's top results happen to form one long contiguous
+  // chain (one slot, many chunks — see capToDistinctLimit above) while
+  // another injury contributes only single, non-adjacent chunks, the first
+  // injury can still supply disproportionately more of the actual prompt
+  // content even though slot counts stay even.
   const perInjuryLimit = Math.max(1, Math.ceil(limit / matchedInjuryIds.length));
 
   const perInjuryResults = await Promise.all(
@@ -49,7 +110,7 @@ export async function semanticSearch(
       searchSimilarChunks(
         result.embedding,
         matchedInjuryId,
-        perInjuryLimit,
+        perInjuryLimit * OVERFETCH_FACTOR,
         undefined,
         userId,
         requestId,
@@ -58,8 +119,5 @@ export async function semanticSearch(
     ),
   );
 
-  return perInjuryResults
-    .flat()
-    .sort((a, b) => a.distance - b.distance)
-    .slice(0, limit);
+  return capToDistinctLimit(perInjuryResults.flat(), limit);
 }

--- a/src/retrieval/semantic-search.ts
+++ b/src/retrieval/semantic-search.ts
@@ -31,8 +31,6 @@ function capToDistinctLimit<T extends DedupableChunk>(chunks: T[], limit: number
   let distinctCount = 0;
 
   for (const chunk of sorted) {
-    if (distinctCount >= limit) break;
-
     const isAdjacentToKept = kept.some(
       (keptChunk) =>
         keptChunk.sourceType === chunk.sourceType &&
@@ -40,9 +38,15 @@ function capToDistinctLimit<T extends DedupableChunk>(chunks: T[], limit: number
         Math.abs(keptChunk.chunkIndex - chunk.chunkIndex) <= 1,
     );
 
-    kept.push(chunk);
-
-    if (!isAdjacentToKept) {
+    // Adjacency is checked before the limit gate: a later-ranked chunk that's
+    // adjacent to one already kept must never be dropped just because the
+    // distinct-slot target was already reached by earlier, unrelated chunks
+    // (#231 review) — only a genuinely new (non-adjacent) source is subject
+    // to the limit.
+    if (isAdjacentToKept) {
+      kept.push(chunk);
+    } else if (distinctCount < limit) {
+      kept.push(chunk);
       distinctCount += 1;
     }
   }

--- a/tests/semantic-search.test.ts
+++ b/tests/semantic-search.test.ts
@@ -63,7 +63,7 @@ describe('semanticSearch', () => {
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       embedding,
       9,
-      5,
+      10,
       undefined,
       1,
       undefined,
@@ -103,6 +103,40 @@ describe('semanticSearch', () => {
     ]);
   });
 
+  it('keeps an adjacent duplicate from the merged multi-injury result set without consuming a distinct slot (#215)', async () => {
+    embedQueryMock.mockResolvedValue({
+      embedding: [0.1, 0.2],
+      model: 'test-model',
+      modelVersion: 'v1',
+      dimension: 2,
+      version: 'test-version',
+    });
+
+    routeInjuriesMock.mockResolvedValue([1, 2]);
+
+    searchSimilarChunksMock.mockImplementation(async (_embedding, matchedInjuryId: number) => {
+      if (matchedInjuryId === 1) {
+        return [
+          { id: 10, injuryId: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.1 },
+          { id: 11, injuryId: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.15 },
+        ];
+      }
+
+      return [{ id: 20, injuryId: 2, sourceType: 'journal', sourceId: 9, chunkIndex: 0, distance: 0.3 }];
+    });
+
+    const result = await semanticSearch('a broad question', undefined, 1, 2);
+
+    // limit=2, but id 11 (adjacent to id 10) doesn't count toward it, so all
+    // 3 chunks are returned — 2 distinct sources (id 10's and id 20's), with
+    // id 11's content still included rather than dropped.
+    expect(result).toEqual([
+      { id: 10, injuryId: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.1 },
+      { id: 11, injuryId: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.15 },
+      { id: 20, injuryId: 2, sourceType: 'journal', sourceId: 9, chunkIndex: 0, distance: 0.3 },
+    ]);
+  });
+
   it('apportions the limit fairly across matched injuries so one cannot crowd out another', async () => {
     embedQueryMock.mockResolvedValue({
       embedding: [0.1, 0.2],
@@ -118,12 +152,12 @@ describe('semanticSearch', () => {
 
     await semanticSearch('a broad question', undefined, 1, 5);
 
-    // limit=5 across 3 matched injuries: ceil(5/3) = 2 per injury.
+    // limit=5 across 3 matched injuries: ceil(5/3) = 2 per injury, over-fetched x2 = 4.
     expect(searchSimilarChunksMock).toHaveBeenCalledTimes(3);
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
       1,
-      2,
+      4,
       undefined,
       1,
       undefined,
@@ -132,7 +166,7 @@ describe('semanticSearch', () => {
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
       2,
-      2,
+      4,
       undefined,
       1,
       undefined,
@@ -141,7 +175,7 @@ describe('semanticSearch', () => {
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
       3,
-      2,
+      4,
       undefined,
       1,
       undefined,
@@ -182,7 +216,7 @@ describe('semanticSearch', () => {
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
       42,
-      5,
+      10,
       undefined,
       1,
       undefined,
@@ -216,6 +250,111 @@ describe('semanticSearch', () => {
     await expect(semanticSearch('lower back pain', 42, 1)).rejects.toThrow(
       'database unavailable',
     );
+  });
+
+  it('keeps an adjacent duplicate but does not let it consume a distinct slot (#215)', async () => {
+    embedQueryMock.mockResolvedValue({
+      embedding: [0.1, 0.2],
+      model: 'test-model',
+      modelVersion: 'v1',
+      dimension: 2,
+      version: 'test-version',
+    });
+
+    searchSimilarChunksMock.mockResolvedValue([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.05 },
+      { id: 2, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.1 },
+      { id: 3, sourceType: 'journal', sourceId: 7, chunkIndex: 8, distance: 0.2 },
+    ]);
+
+    const result = await semanticSearch('lower back pain', 42, 1, 5);
+
+    // All 3 chunks are returned — id 2 is adjacent to id 1 and doesn't count
+    // toward the limit, but its content is never dropped.
+    expect(result).toEqual([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.05 },
+      { id: 2, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.1 },
+      { id: 3, sourceType: 'journal', sourceId: 7, chunkIndex: 8, distance: 0.2 },
+    ]);
+  });
+
+  it('collapses a whole run of mutually-adjacent chunks into a single distinct slot (#215)', async () => {
+    embedQueryMock.mockResolvedValue({
+      embedding: [0.1, 0.2],
+      model: 'test-model',
+      modelVersion: 'v1',
+      dimension: 2,
+      version: 'test-version',
+    });
+
+    searchSimilarChunksMock.mockResolvedValue([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.05 },
+      { id: 2, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.06 },
+      { id: 3, sourceType: 'journal', sourceId: 7, chunkIndex: 4, distance: 0.07 },
+      { id: 4, sourceType: 'journal', sourceId: 9, chunkIndex: 0, distance: 0.08 },
+    ]);
+
+    const result = await semanticSearch('lower back pain', 42, 1, 2);
+
+    // ids 1-2-3 form one contiguous run (each adjacent to the next) and
+    // together count as only 1 of the 2 requested slots — every chunk in
+    // the run is still returned. id 4 (a different source) fills the 2nd
+    // distinct slot, so all 4 chunks come back even though limit=2.
+    expect(result).toEqual([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.05 },
+      { id: 2, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.06 },
+      { id: 3, sourceType: 'journal', sourceId: 7, chunkIndex: 4, distance: 0.07 },
+      { id: 4, sourceType: 'journal', sourceId: 9, chunkIndex: 0, distance: 0.08 },
+    ]);
+  });
+
+  it('keeps non-adjacent chunks from the same source', async () => {
+    embedQueryMock.mockResolvedValue({
+      embedding: [0.1, 0.2],
+      model: 'test-model',
+      modelVersion: 'v1',
+      dimension: 2,
+      version: 'test-version',
+    });
+
+    searchSimilarChunksMock.mockResolvedValue([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 0, distance: 0.05 },
+      { id: 2, sourceType: 'journal', sourceId: 7, chunkIndex: 5, distance: 0.1 },
+    ]);
+
+    const result = await semanticSearch('lower back pain', 42, 1, 5);
+
+    expect(result).toEqual([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 0, distance: 0.05 },
+      { id: 2, sourceType: 'journal', sourceId: 7, chunkIndex: 5, distance: 0.1 },
+    ]);
+  });
+
+  it('can return more than limit chunks when an adjacent duplicate fills a distinct slot', async () => {
+    embedQueryMock.mockResolvedValue({
+      embedding: [0.1, 0.2],
+      model: 'test-model',
+      modelVersion: 'v1',
+      dimension: 2,
+      version: 'test-version',
+    });
+
+    searchSimilarChunksMock.mockResolvedValue([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.05 },
+      { id: 2, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.06 },
+      { id: 3, sourceType: 'journal', sourceId: 9, chunkIndex: 1, distance: 0.07 },
+    ]);
+
+    const result = await semanticSearch('lower back pain', 42, 1, 2);
+
+    // limit=2, but id 2 (adjacent to id 1) doesn't count toward it, so a 3rd
+    // (distinct) chunk is pulled in to reach 2 distinct sources — nothing
+    // is ever dropped to stay at exactly `limit`.
+    expect(result).toEqual([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.05 },
+      { id: 2, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.06 },
+      { id: 3, sourceType: 'journal', sourceId: 9, chunkIndex: 1, distance: 0.07 },
+    ]);
   });
 
   it('propagates injury-routing errors for unscoped queries', async () => {

--- a/tests/semantic-search.test.ts
+++ b/tests/semantic-search.test.ts
@@ -308,6 +308,34 @@ describe('semanticSearch', () => {
     ]);
   });
 
+  it('retains a late-ranked adjacent chunk even after the distinct-slot target is reached (#231 review)', async () => {
+    embedQueryMock.mockResolvedValue({
+      embedding: [0.1, 0.2],
+      model: 'test-model',
+      modelVersion: 'v1',
+      dimension: 2,
+      version: 'test-version',
+    });
+
+    searchSimilarChunksMock.mockResolvedValue([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.1 },
+      { id: 2, sourceType: 'journal', sourceId: 9, chunkIndex: 0, distance: 0.15 },
+      { id: 3, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.2 },
+    ]);
+
+    const result = await semanticSearch('lower back pain', 42, 1, 2);
+
+    // limit=2 is reached by id 1 and id 2 (2 distinct sources). id 3 ranks
+    // last but is adjacent to id 1 (same source, chunkIndex within 1) — it
+    // must still be retained, not dropped just because the distinct target
+    // was already met by earlier, unrelated chunks.
+    expect(result).toEqual([
+      { id: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.1 },
+      { id: 2, sourceType: 'journal', sourceId: 9, chunkIndex: 0, distance: 0.15 },
+      { id: 3, sourceType: 'journal', sourceId: 7, chunkIndex: 3, distance: 0.2 },
+    ]);
+  });
+
   it('keeps non-adjacent chunks from the same source', async () => {
     embedQueryMock.mockResolvedValue({
       embedding: [0.1, 0.2],


### PR DESCRIPTION
## Summary

Since chunk overlap was added (#135), retrieval could return two adjacent
chunks sharing most of their text, wasting a result slot on redundant
content. This fixes it without ever dropping content — an important
constraint given this is healthcare journal data:

- `semanticSearch` now over-fetches, and when it finds a run of
  mutually-adjacent chunks from the same source, keeps every chunk in
  the run but only counts it once toward the caller's `limit`.
- The result can now exceed `limit` (bounded by the over-fetch pool
  size) rather than ever discarding a chunk's unique content.
- Documented two known tradeoffs in `docs/02-architecture.md` (D4/D5):
  the fixed over-fetch window isn't adaptive, and the #209/D11 fair-share
  apportionment across injuries is fair in slot count but not
  necessarily in raw content volume.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (full suite — same 9 pre-existing, unrelated
      DB/JWT-credential integration failures as before this change;
      `tests/semantic-search.test.ts` 13/13 pass)
- [x] Evaluation harness attempted per CLAUDE.md §10 (retrieval change);
      seeding/ingestion succeeded, but `eval:full` hit a Groq daily
      token-quota exhaustion (199,970/200,000 TPD), not something a
      retry fixes today — treating same-session unit coverage as
      sufficient verification for now

Fixes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved semantic search to retain relevant adjacent chunks from the same source while counting them as a single distinct result.
  * Search results and citations may now include more chunks than the requested limit when additional adjacent context is relevant.
  * Non-adjacent chunks continue to count separately toward the distinct-result limit.

* **Documentation**
  * Updated architecture and service documentation to clarify result-limit behavior and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->