### PR TITLE
fix: remove duplicate evaluateNoInformation import in evaluation-runner.ts

### DIFF
--- a/evaluation/ai-system/evaluation-runner.ts
+++ b/evaluation/ai-system/evaluation-runner.ts
@@ -5,7 +5,6 @@ import {
   evaluateCitations,
   evaluateNoInformation,
   evaluateIntent,
-  evaluateNoInformation,
 } from './evaluator-metrics.js';
 import { evaluateRetrieval } from './retrieval-metrics.js';
 import { evaluateFaithfulness } from './faithfulness-judge.js';


### PR DESCRIPTION
`evaluation/ai-system/evaluation-runner.ts` imported `evaluateNoInformation` twice in the
same import clause — dead duplication, likely leftover from a merge. `tsc --noEmit`
doesn't flag it since it dedupes silently.

Removes the duplicate entry.

Fixes #222