### PR TITLE
fix: resolve eval dataset sourceIds by name, not hardcoded ID

### DIFF
--- a/evaluation/ai-system/dataset.json
+++ b/evaluation/ai-system/dataset.json
@@ -9,7 +9,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 2
+        "injuryId": 1,
+        "match": "Shockwave therapy"
       }
     ]
   },
@@ -23,7 +24,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Physiotherapy"
       }
     ]
   },
@@ -37,7 +39,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Physiotherapy"
       }
     ]
   },
@@ -52,11 +55,13 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Physiotherapy"
       },
       {
         "sourceType": "treatment",
-        "sourceId": 2
+        "injuryId": 1,
+        "match": "Shockwave therapy"
       }
     ]
   },
@@ -70,11 +75,13 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Physiotherapy"
       },
       {
         "sourceType": "treatment",
-        "sourceId": 2
+        "injuryId": 1,
+        "match": "Shockwave therapy"
       }
     ]
   },
@@ -88,7 +95,8 @@
     "expectedSources": [
       {
         "sourceType": "symptom",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Burning pain after standing for a long time."
       }
     ]
   },
@@ -102,7 +110,8 @@
     "expectedSources": [
       {
         "sourceType": "medical_visit",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Dr. Smith"
       }
     ]
   },
@@ -116,7 +125,7 @@
     "expectedSources": [
       {
         "sourceType": "injury",
-        "sourceId": 1
+        "match": "Lower back pain"
       }
     ]
   },
@@ -228,7 +237,8 @@
     "expectedSources": [
       {
         "sourceType": "medical_visit",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Dr. Smith"
       }
     ]
   },
@@ -251,7 +261,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 2
+        "injuryId": 1,
+        "match": "Shockwave therapy"
       }
     ]
   },
@@ -265,7 +276,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 5
+        "injuryId": 4,
+        "match": "Foam rolling and rest"
       }
     ]
   },

--- a/evaluation/ai-system/evaluation-runner.ts
+++ b/evaluation/ai-system/evaluation-runner.ts
@@ -8,6 +8,7 @@ import {
 } from './evaluator-metrics.js';
 import { evaluateRetrieval } from './retrieval-metrics.js';
 import { evaluateFaithfulness } from './faithfulness-judge.js';
+import { resolveExpectedSources } from './resolve-expected-sources.js';
 import type { EvaluationResult } from './evaluation-types.js';
 
 const MAX_RATE_LIMIT_RETRIES = 5;
@@ -70,6 +71,26 @@ export async function runEvaluation() {
       item.injuryId,
     );
 
+    // A fixture that no longer resolves (renamed/removed in prisma/seed-dev.ts)
+    // should only invalidate this case's retrieval score, not the whole run —
+    // the other checks below, and every other case in the dataset, are still
+    // meaningful even when one case's expected-source description is stale.
+    let retrievalPassed: boolean | null;
+    try {
+      const resolvedExpectedSources = await resolveExpectedSources(
+        item.expectedSources ?? [],
+        item.userId,
+        item.id,
+      );
+      retrievalPassed = evaluateRetrieval(
+        resolvedExpectedSources,
+        output.metadata?.retrievedChunks ?? [],
+      );
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : error);
+      retrievalPassed = null;
+    }
+
     results.push({
       id: item.id,
       question: item.question,
@@ -81,17 +102,13 @@ export async function runEvaluation() {
         safetyPassed: evaluateSafety(item.expectedBehavior, output),
         citationsPassed: evaluateCitations(item.expectedBehavior, output),
         intentPassed: evaluateIntent(item.expectedIntent, output),
-        retrievalPassed: evaluateRetrieval(
-          item.expectedSources ?? [],
-          output.metadata?.retrievedChunks ?? [],
-        ),
+        retrievalPassed,
         noInformationPassed: evaluateNoInformation(item.expectedBehavior, output),
         faithfulnessPassed: await evaluateFaithfulness(
           item.expectedBehavior,
           output.answer,
           output.metadata?.retrievedChunks ?? [],
         ),
-        noInformationPassed: evaluateNoInformation(item.expectedBehavior, output),
       },
     });
   }

--- a/evaluation/ai-system/resolve-expected-sources.ts
+++ b/evaluation/ai-system/resolve-expected-sources.ts
@@ -1,0 +1,78 @@
+import { prisma } from '../../src/lib/prisma.js';
+
+export type ExpectedSourceFixture =
+  | { sourceType: 'treatment'; injuryId: number; match: string }
+  | { sourceType: 'symptom'; injuryId: number; match: string }
+  | { sourceType: 'medical_visit'; injuryId: number; match: string }
+  | { sourceType: 'injury'; match: string };
+
+// take: 2 is enough to detect "more than one match" without fetching every match.
+async function findMatches(
+  fixture: ExpectedSourceFixture,
+  userId: number,
+): Promise<Array<{ id: number }>> {
+  switch (fixture.sourceType) {
+    case 'treatment':
+      return prisma.treatment.findMany({
+        where: { injuryId: fixture.injuryId, name: fixture.match },
+        select: { id: true },
+        take: 2,
+      });
+    case 'symptom':
+      return prisma.symptom.findMany({
+        where: { injuryId: fixture.injuryId, notes: fixture.match },
+        select: { id: true },
+        take: 2,
+      });
+    case 'medical_visit':
+      return prisma.medicalVisit.findMany({
+        where: { injuryId: fixture.injuryId, doctor: fixture.match },
+        select: { id: true },
+        take: 2,
+      });
+    case 'injury':
+      return prisma.injury.findMany({
+        where: { userId, name: fixture.match },
+        select: { id: true },
+        take: 2,
+      });
+  }
+}
+
+// Eval dataset cases describe expected retrieval sources by name (e.g. a
+// treatment's name) instead of a hardcoded Prisma autoincrement ID, since
+// that ID drifts silently whenever prisma/seed-dev.ts fixtures change. This
+// resolves each description to the real current ID right before scoring, so
+// a fixture that no longer exists — or now matches more than one record —
+// fails loudly instead of comparing against the wrong one.
+export async function resolveExpectedSources(
+  fixtures: ExpectedSourceFixture[],
+  userId: number,
+  caseId: string,
+): Promise<Array<{ sourceType: string; sourceId: number }>> {
+  return Promise.all(
+    fixtures.map(async (fixture) => {
+      const matches = await findMatches(fixture, userId);
+      const scope =
+        fixture.sourceType === 'injury'
+          ? `for user ${userId}`
+          : `in injury ${fixture.injuryId}`;
+
+      if (matches.length === 0) {
+        throw new Error(
+          `Eval case "${caseId}": no ${fixture.sourceType} matching "${fixture.match}" found ${scope}. ` +
+            'Check prisma/seed-dev.ts fixtures.',
+        );
+      }
+
+      if (matches.length > 1) {
+        throw new Error(
+          `Eval case "${caseId}": more than one ${fixture.sourceType} matches "${fixture.match}" ${scope} ` +
+            '— the fixture description is no longer unique. Check prisma/seed-dev.ts fixtures.',
+        );
+      }
+
+      return { sourceType: fixture.sourceType, sourceId: matches[0].id };
+    }),
+  );
+}

--- a/tests/evaluation-dataset.test.ts
+++ b/tests/evaluation-dataset.test.ts
@@ -18,7 +18,11 @@ describe('evaluation dataset', () => {
       if (Array.isArray(sources)) {
         for (const source of sources) {
           expect(source.sourceType).toEqual(expect.stringMatching(/\S+/));
-          expect(source.sourceId).toEqual(expect.anything());
+          expect(source.match).toEqual(expect.stringMatching(/\S+/));
+          if (source.sourceType !== 'injury') {
+            expect(source.injuryId).toEqual(expect.any(Number));
+            expect(source.injuryId).toBeGreaterThan(0);
+          }
         }
       }
     }

--- a/tests/evaluation-runner.test.ts
+++ b/tests/evaluation-runner.test.ts
@@ -3,6 +3,7 @@ import dataset from '../evaluation/ai-system/dataset.json';
 
 const runAgentMock = jest.fn();
 const evaluateFaithfulnessMock = jest.fn();
+const resolveExpectedSourcesMock = jest.fn();
 
 jest.unstable_mockModule('../src/ai-agent/ai-agent-orchestrator.js', () => ({
   runAgent: runAgentMock,
@@ -10,6 +11,10 @@ jest.unstable_mockModule('../src/ai-agent/ai-agent-orchestrator.js', () => ({
 
 jest.unstable_mockModule('../evaluation/ai-system/faithfulness-judge.js', () => ({
   evaluateFaithfulness: evaluateFaithfulnessMock,
+}));
+
+jest.unstable_mockModule('../evaluation/ai-system/resolve-expected-sources.js', () => ({
+  resolveExpectedSources: resolveExpectedSourcesMock,
 }));
 
 const { runEvaluation } =
@@ -20,6 +25,7 @@ describe('evaluation runner', () => {
     jest.clearAllMocks();
 
     evaluateFaithfulnessMock.mockResolvedValue(true);
+    resolveExpectedSourcesMock.mockResolvedValue([]);
   });
 
   it('runs evaluation questions through the AI agent', async () => {
@@ -68,5 +74,29 @@ describe('evaluation runner', () => {
     }
 
     expect(results[0].evaluation).toHaveProperty('faithfulnessPassed', true);
+  });
+
+  it('contains an expected-source resolution failure to that case instead of aborting the run', async () => {
+    runAgentMock.mockResolvedValue({
+      answer: 'Shockwave therapy failed.',
+      citations: [],
+    });
+
+    resolveExpectedSourcesMock.mockRejectedValueOnce(
+      new Error('no treatment matching "Shockwave therapy" found'),
+    );
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const results = await runEvaluation();
+
+    expect(results.length).toBe(dataset.length);
+    expect(results[0].evaluation.retrievalPassed).toBeNull();
+    expect(results[1].evaluation.retrievalPassed).not.toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('no treatment matching "Shockwave therapy" found'),
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/tests/resolve-expected-sources.test.ts
+++ b/tests/resolve-expected-sources.test.ts
@@ -1,0 +1,124 @@
+import { jest } from '@jest/globals';
+
+const prismaMock = {
+  treatment: { findMany: jest.fn() },
+  symptom: { findMany: jest.fn() },
+  medicalVisit: { findMany: jest.fn() },
+  injury: { findMany: jest.fn() },
+};
+
+jest.unstable_mockModule('../src/lib/prisma.js', () => ({
+  prisma: prismaMock,
+}));
+
+const { resolveExpectedSources } = await import(
+  '../evaluation/ai-system/resolve-expected-sources.js'
+);
+
+describe('resolveExpectedSources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves a treatment by name scoped to its injury', async () => {
+    prismaMock.treatment.findMany.mockResolvedValue([{ id: 2 }]);
+
+    const result = await resolveExpectedSources(
+      [{ sourceType: 'treatment', injuryId: 1, match: 'Shockwave therapy' }],
+      1,
+      'case-1',
+    );
+
+    expect(prismaMock.treatment.findMany).toHaveBeenCalledWith({
+      where: { injuryId: 1, name: 'Shockwave therapy' },
+      select: { id: true },
+      take: 2,
+    });
+    expect(result).toEqual([{ sourceType: 'treatment', sourceId: 2 }]);
+  });
+
+  it('resolves a symptom by notes scoped to its injury', async () => {
+    prismaMock.symptom.findMany.mockResolvedValue([{ id: 1 }]);
+
+    const result = await resolveExpectedSources(
+      [{ sourceType: 'symptom', injuryId: 1, match: 'Burning pain.' }],
+      1,
+      'case-2',
+    );
+
+    expect(prismaMock.symptom.findMany).toHaveBeenCalledWith({
+      where: { injuryId: 1, notes: 'Burning pain.' },
+      select: { id: true },
+      take: 2,
+    });
+    expect(result).toEqual([{ sourceType: 'symptom', sourceId: 1 }]);
+  });
+
+  it('resolves a medical visit by doctor scoped to its injury', async () => {
+    prismaMock.medicalVisit.findMany.mockResolvedValue([{ id: 1 }]);
+
+    const result = await resolveExpectedSources(
+      [{ sourceType: 'medical_visit', injuryId: 1, match: 'Dr. Smith' }],
+      1,
+      'case-3',
+    );
+
+    expect(prismaMock.medicalVisit.findMany).toHaveBeenCalledWith({
+      where: { injuryId: 1, doctor: 'Dr. Smith' },
+      select: { id: true },
+      take: 2,
+    });
+    expect(result).toEqual([{ sourceType: 'medical_visit', sourceId: 1 }]);
+  });
+
+  it('resolves an injury by name scoped to the user', async () => {
+    prismaMock.injury.findMany.mockResolvedValue([{ id: 1 }]);
+
+    const result = await resolveExpectedSources(
+      [{ sourceType: 'injury', match: 'Lower back pain' }],
+      1,
+      'case-4',
+    );
+
+    expect(prismaMock.injury.findMany).toHaveBeenCalledWith({
+      where: { userId: 1, name: 'Lower back pain' },
+      select: { id: true },
+      take: 2,
+    });
+    expect(result).toEqual([{ sourceType: 'injury', sourceId: 1 }]);
+  });
+
+  it('throws a descriptive error when no record matches', async () => {
+    prismaMock.treatment.findMany.mockResolvedValue([]);
+
+    await expect(
+      resolveExpectedSources(
+        [{ sourceType: 'treatment', injuryId: 1, match: 'Nonexistent treatment' }],
+        1,
+        'case-missing',
+      ),
+    ).rejects.toThrow(
+      'Eval case "case-missing": no treatment matching "Nonexistent treatment" found in injury 1. Check prisma/seed-dev.ts fixtures.',
+    );
+  });
+
+  it('throws a descriptive error when more than one record matches', async () => {
+    prismaMock.treatment.findMany.mockResolvedValue([{ id: 1 }, { id: 7 }]);
+
+    await expect(
+      resolveExpectedSources(
+        [{ sourceType: 'treatment', injuryId: 1, match: 'Physiotherapy' }],
+        1,
+        'case-ambiguous',
+      ),
+    ).rejects.toThrow(
+      'Eval case "case-ambiguous": more than one treatment matches "Physiotherapy" in injury 1 — the fixture description is no longer unique. Check prisma/seed-dev.ts fixtures.',
+    );
+  });
+
+  it('returns an empty array for no fixtures', async () => {
+    const result = await resolveExpectedSources([], 1, 'case-empty');
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Eval dataset cases now describe expected retrieval sources by a plain-English natural key (e.g. treatment name) instead of a hardcoded Prisma autoincrement ID, since that ID drifted silently whenever `prisma/seed-dev.ts` fixtures changed.
- `resolve-expected-sources.ts` resolves each description to the real current ID at eval-run time; a fixture that no longer matches exactly one record fails loudly with a clear message instead of comparing against the wrong (or a missing) record.
- A single stale/ambiguous fixture only invalidates that case's retrieval score (`retrievalPassed: null`, logged) rather than aborting the whole eval run.

Fixes #190

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (355 passed, including new `resolve-expected-sources.test.ts` and updated dataset/runner tests)