### PR TITLE
Track embedding model/version on DocumentChunk (#133)

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -232,6 +232,9 @@ flowchart TD
 > As of #209 (see D11), when `injuryId` is omitted this diagram's "Metadata Filtering" step is
 > preceded by an injury-routing step (`injury-router.ts`) that picks the `injuryId`(s) to filter on
 > from the question itself, instead of searching unfiltered across all of a user's injuries.
+> As of #133 (see D12), "Metadata Filtering" also always includes an `embeddingModel`/
+> `embeddingModelVersion` match against the query's own embedding metadata — not optional, and not
+> shown as a separate diagram step since it applies uniformly to every call.
 
 ### Sequence Diagram
 
@@ -253,7 +256,7 @@ sequenceDiagram
     E-->>A: Normalized query vector
     A-->>C: Embedding response
     C-->>S: Validated embedding
-    S->>V: searchSimilarChunks(vector, injuryId, limit, sourceType, userId)
+    S->>V: searchSimilarChunks(vector, embeddingModel, embeddingModelVersion, injuryId, limit, sourceType, userId)
     V-->>S: Similar chunks
     S-->>R: Search results
 ```
@@ -877,3 +880,39 @@ quoted), what else was considered, whether it still holds, and whether it should
   injuries," or if evaluation data (once it has broad/multi-injury unscoped cases — see
   `evaluation/ai-system/dataset.json`'s `rag-unscoped-multi-injury-001`) shows any of the three
   `src/config/retrieval.ts` constants need recalibrating.
+
+### D12 — `embeddingModel`/`embeddingModelVersion` are real, indexed columns on `DocumentChunk`, and `searchSimilarChunks` refuses to compare across them (#133)
+
+- **DECISION:** `DocumentChunk` has two required, indexed columns, `embeddingModel` and
+  `embeddingModelVersion`, recorded at write time from the embedding service's response
+  (`embed-and-store.ts`). `searchSimilarChunks` always filters on both, in addition to its existing
+  `injuryId`/`sourceType`/`userId` filters — a query embedded by one model/version never gets
+  compared by cosine distance against a chunk embedded by a different one.
+- **RATIONALE:** `DocumentChunk.embedding` is `vector(1024)` with nothing else distinguishing which
+  model produced a given vector (see D1/D2). Cosine distance between vectors from two different
+  models is meaningless, but nothing previously stopped it — if the embedding model were ever
+  changed, old and new vectors would silently mix in every search, corrupting rankings with no
+  error. The model/version was already being computed and returned by the embedding service, but
+  only ever landed inside the unindexed `metadata` JSON blob (`embed-and-store.ts`), never
+  consulted by retrieval — the same shape of gap D9 documented for `userId` before #41 fixed it.
+- **ALTERNATIVES CONSIDERED:** Leave it in the JSON blob and rely on operational discipline (e.g. a
+  full re-embed done atomically, with search taken offline during the switch) whenever the model
+  changes — rejected because it turns any future model change into a hard-cutover/downtime event,
+  and provides no protection if that discipline is forgotten. Promoting all four
+  `embed-and-store.ts` metadata fields (`model`, `modelVersion`, `vectorDimension`,
+  `embeddingVersion`) to columns — rejected as unnecessary scope: only `model`/`modelVersion`
+  uniquely identify which weights produced a vector, which is what the guard needs;
+  `vectorDimension`/`embeddingVersion` stay in `metadata`.
+- **CURRENT STATUS:** Implemented. Migration `20260830120000_add_embedding_model_version` backfills
+  existing rows from `metadata.embedding.model`/`.modelVersion`, falling back to the one model this
+  project has ever used in production (`Qwen/Qwen3-Embedding-0.6B`) for any row missing it, before
+  making both columns `NOT NULL`. `searchSimilarChunks`, `storeDocumentChunk`, `routeInjuries`, and
+  `semanticSearch` all thread the values through (see `src/embeddings/vector-storage.ts`,
+  `src/retrieval/injury-router.ts`, `src/retrieval/semantic-search.ts`).
+- **INTERACTION WITH A FUTURE MODEL CHANGE:** Because the guard excludes rather than errors, a model
+  change can now be rolled out as a gradual background re-embed instead of a hard cutover: chunks
+  not yet re-embedded under the new model/version simply stop matching new queries (safe, visible
+  degradation) rather than being compared against vectors they're incompatible with.
+- **SHOULD THIS BE REVISITED:** No — revisit only alongside an actual embedding-model change, at
+  which point the migration's "assume current model" backfill fallback (safe today because only one
+  model has ever been used) should not be reused as-is for backfilling genuinely mixed-model data.

--- a/prisma/migrations/20260830120000_add_embedding_model_version/migration.sql
+++ b/prisma/migrations/20260830120000_add_embedding_model_version/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Track which embedding model (and model version) produced each chunk's
+  vector, so retrieval can refuse to compare vectors from different
+  models. `embedding` is `vector(1024)` with no other way to tell two
+  vectors from different models apart, and cosine distance between them
+  is meaningless.
+
+  Backfilled from the model/version info already recorded (unindexed)
+  inside `metadata.embedding`, with a fallback to the currently deployed
+  model for any row that predates that metadata.
+*/
+
+-- Add the columns as nullable first.
+ALTER TABLE "DocumentChunk"
+ADD COLUMN "embeddingModel" TEXT,
+ADD COLUMN "embeddingModelVersion" TEXT;
+
+-- Backfill from metadata.embedding, falling back to the currently
+-- deployed model for rows that never recorded it.
+UPDATE "DocumentChunk"
+SET
+  "embeddingModel" = COALESCE(metadata->'embedding'->>'model', 'Qwen/Qwen3-Embedding-0.6B'),
+  "embeddingModelVersion" = COALESCE(metadata->'embedding'->>'modelVersion', '97b0c614be4d77ee51c0cef4e5f07c00f9eb65b3')
+WHERE "embeddingModel" IS NULL;
+
+-- Now that every existing row has a value, make both required.
+ALTER TABLE "DocumentChunk"
+ALTER COLUMN "embeddingModel" SET NOT NULL,
+ALTER COLUMN "embeddingModelVersion" SET NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "DocumentChunk_embeddingModel_embeddingModelVersion_idx" ON "DocumentChunk"("embeddingModel", "embeddingModelVersion");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,21 +92,24 @@ model User {
 }
 
 model DocumentChunk {
-  id          Int      @id @default(autoincrement())
-  injuryId    Int
-  userId      Int
-  sourceType  String
-  sourceId    Int
-  chunkIndex  Int
-  content     String
-  embedding   Unsupported("vector(1024)")?
-  metadata    Json?
-  createdAt   DateTime @default(now())
+  id                    Int      @id @default(autoincrement())
+  injuryId              Int
+  userId                Int
+  sourceType            String
+  sourceId              Int
+  chunkIndex            Int
+  content               String
+  embedding             Unsupported("vector(1024)")?
+  embeddingModel        String
+  embeddingModelVersion String
+  metadata              Json?
+  createdAt             DateTime @default(now())
 
   Injury Injury @relation(fields: [injuryId], references: [id])
 
   @@index([injuryId])
   @@index([userId])
   @@index([sourceType, sourceId])
+  @@index([embeddingModel, embeddingModelVersion])
   @@unique([sourceType, sourceId, chunkIndex])
 }

--- a/src/embeddings/vector-storage.ts
+++ b/src/embeddings/vector-storage.ts
@@ -38,6 +38,8 @@ export async function storeDocumentChunk(
   chunkIndex: number,
   content: string,
   embedding: number[],
+  embeddingModel: string,
+  embeddingModelVersion: string,
   metadata?: Record<string, unknown>,
 ): Promise<void> {
   const vector = `[${embedding.join(',')}]`;
@@ -52,6 +54,8 @@ export async function storeDocumentChunk(
         "chunkIndex",
         "content",
         "embedding",
+        "embeddingModel",
+        "embeddingModelVersion",
         "metadata"
       )
       VALUES (
@@ -62,6 +66,8 @@ export async function storeDocumentChunk(
         ${chunkIndex},
         ${content},
         ${vector}::vector,
+        ${embeddingModel},
+        ${embeddingModelVersion},
         ${metadata ? JSON.stringify(metadata) : null}::jsonb
       )
       ON CONFLICT ("sourceType", "sourceId", "chunkIndex")
@@ -70,6 +76,8 @@ export async function storeDocumentChunk(
         "userId" = EXCLUDED."userId",
         "content" = EXCLUDED."content",
         "embedding" = EXCLUDED."embedding",
+        "embeddingModel" = EXCLUDED."embeddingModel",
+        "embeddingModelVersion" = EXCLUDED."embeddingModelVersion",
         "metadata" = EXCLUDED."metadata"
     `,
   );
@@ -104,6 +112,8 @@ export async function deleteDocumentChunksExcept(
 
 export async function searchSimilarChunks(
   embedding: number[],
+  embeddingModel: string,
+  embeddingModelVersion: string,
   injuryId?: number,
   limit = 5,
   sourceType?: string,
@@ -117,6 +127,11 @@ export async function searchSimilarChunks(
 
   const filters: Prisma.Sql[] = [
     Prisma.sql`"embedding" <=> ${vector}::vector <= ${maxDistance}`,
+    // Vectors from a different model (or model version) live in a
+    // different space entirely — comparing them by cosine distance would
+    // be meaningless. Only compare chunks embedded by the same model.
+    Prisma.sql`"embeddingModel" = ${embeddingModel}`,
+    Prisma.sql`"embeddingModelVersion" = ${embeddingModelVersion}`,
   ];
   if (injuryId !== undefined) filters.push(Prisma.sql`"injuryId" = ${injuryId}`);
   if (sourceType !== undefined) filters.push(Prisma.sql`"sourceType" = ${sourceType}`);

--- a/src/ingestion/embed-and-store.ts
+++ b/src/ingestion/embed-and-store.ts
@@ -40,9 +40,14 @@ export async function embedAndStoreDocument(
           chunkIndex,
           embeddedDocument.document.content,
           embeddedDocument.embedding,
+          embeddedDocument.embeddingMetadata.model,
+          embeddedDocument.embeddingMetadata.modelVersion,
           {
             ...embeddedDocument.document.metadata,
-            embedding: embeddedDocument.embeddingMetadata,
+            embedding: {
+              vectorDimension: embeddedDocument.embeddingMetadata.vectorDimension,
+              embeddingVersion: embeddedDocument.embeddingMetadata.embeddingVersion,
+            },
           },
         );
       }

--- a/src/retrieval/injury-router.ts
+++ b/src/retrieval/injury-router.ts
@@ -17,6 +17,8 @@ const INJURY_CANDIDATE_LIMIT = 50;
 // src/config/retrieval.ts for why.
 export async function routeInjuries(
   embedding: number[],
+  embeddingModel: string,
+  embeddingModelVersion: string,
   userId: number,
   requestId?: string,
 ): Promise<number[]> {
@@ -26,6 +28,8 @@ export async function routeInjuries(
   // otherwise drop, to decide whether the question matches any injury at all.
   const injuryChunks = await searchSimilarChunks(
     embedding,
+    embeddingModel,
+    embeddingModelVersion,
     undefined,
     INJURY_CANDIDATE_LIMIT,
     'injury',
@@ -45,6 +49,8 @@ export async function routeInjuries(
     // up empty.
     const anyChunks = await searchSimilarChunks(
       embedding,
+      embeddingModel,
+      embeddingModelVersion,
       undefined,
       INJURY_CANDIDATE_LIMIT,
       undefined,

--- a/src/retrieval/semantic-search.ts
+++ b/src/retrieval/semantic-search.ts
@@ -15,6 +15,8 @@ export async function semanticSearch(
   if (injuryId !== undefined) {
     return searchSimilarChunks(
       result.embedding,
+      result.model,
+      result.modelVersion,
       injuryId,
       limit,
       undefined,
@@ -29,7 +31,13 @@ export async function semanticSearch(
   // (#209) — route to the injury/injuries the question is actually about
   // first, then reuse the same scoped search used by the explicit-injuryId
   // path above, which is already known to retrieve correctly.
-  const matchedInjuryIds = await routeInjuries(result.embedding, userId, requestId);
+  const matchedInjuryIds = await routeInjuries(
+    result.embedding,
+    result.model,
+    result.modelVersion,
+    userId,
+    requestId,
+  );
 
   if (matchedInjuryIds.length === 0) {
     return [];
@@ -48,6 +56,8 @@ export async function semanticSearch(
     matchedInjuryIds.map((matchedInjuryId) =>
       searchSimilarChunks(
         result.embedding,
+        result.model,
+        result.modelVersion,
         matchedInjuryId,
         perInjuryLimit,
         undefined,

--- a/tests/embed-and-store.test.ts
+++ b/tests/embed-and-store.test.ts
@@ -39,6 +39,8 @@ const storeDocumentChunkMock =
       chunkIndex: number,
       content: string,
       embedding: number[],
+      embeddingModel: string,
+      embeddingModelVersion: string,
       metadata?: Record<string, unknown>,
     ) => Promise<void>
   >();
@@ -152,11 +154,11 @@ describe('embedAndStoreDocument', () => {
       0,
       'chunk one',
       [1, 1],
+      'test-model',
+      'v1',
       {
         ...document.metadata,
         embedding: {
-          model: 'test-model',
-          modelVersion: 'v1',
           vectorDimension: 2,
           embeddingVersion: 'test-version',
         },
@@ -171,11 +173,11 @@ describe('embedAndStoreDocument', () => {
       1,
       'chunk two',
       [2, 2],
+      'test-model',
+      'v1',
       {
         ...document.metadata,
         embedding: {
-          model: 'test-model',
-          modelVersion: 'v1',
           vectorDimension: 2,
           embeddingVersion: 'test-version',
         },

--- a/tests/injury-router.test.ts
+++ b/tests/injury-router.test.ts
@@ -36,10 +36,12 @@ describe('routeInjuries', () => {
   it('searches only sourceType:injury chunks for this user', async () => {
     searchSimilarChunksMock.mockResolvedValue([injuryChunk(1, 0.1)]);
 
-    await routeInjuries([0.1, 0.2], 7, 'req-1');
+    await routeInjuries([0.1, 0.2], 'test-model', 'v1', 7, 'req-1');
 
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
+      'test-model',
+      'v1',
       undefined,
       50,
       'injury',
@@ -56,7 +58,7 @@ describe('routeInjuries', () => {
       injuryChunk(2, 0.69),
     ]);
 
-    const result = await routeInjuries([0.1, 0.2], 1);
+    const result = await routeInjuries([0.1, 0.2], 'test-model', 'v1', 1);
 
     expect(result).toEqual([3]);
   });
@@ -69,7 +71,7 @@ describe('routeInjuries', () => {
       injuryChunk(4, 0.9),
     ]);
 
-    const result = await routeInjuries([0.1, 0.2], 1);
+    const result = await routeInjuries([0.1, 0.2], 'test-model', 'v1', 1);
 
     expect(result).toEqual([1, 2, 3]);
   });
@@ -77,14 +79,21 @@ describe('routeInjuries', () => {
   it('returns an empty array when the user has no chunks at all', async () => {
     searchSimilarChunksMock.mockResolvedValue([]);
 
-    const result = await routeInjuries([0.1, 0.2], 1);
+    const result = await routeInjuries([0.1, 0.2], 'test-model', 'v1', 1);
 
     expect(result).toEqual([]);
   });
 
   it('falls back to searching any sourceType when the user has chunks but no injury-summary chunk', async () => {
     searchSimilarChunksMock.mockImplementation(
-      async (_embedding, _injuryId, _limit, sourceType: string | undefined) => {
+      async (
+        _embedding,
+        _embeddingModel,
+        _embeddingModelVersion,
+        _injuryId,
+        _limit,
+        sourceType: string | undefined,
+      ) => {
         if (sourceType === 'injury') {
           return [];
         }
@@ -96,12 +105,14 @@ describe('routeInjuries', () => {
       },
     );
 
-    const result = await routeInjuries([0.1, 0.2], 1);
+    const result = await routeInjuries([0.1, 0.2], 'test-model', 'v1', 1);
 
     expect(searchSimilarChunksMock).toHaveBeenCalledTimes(2);
     expect(searchSimilarChunksMock).toHaveBeenNthCalledWith(
       2,
       [0.1, 0.2],
+      'test-model',
+      'v1',
       undefined,
       50,
       undefined,
@@ -120,7 +131,7 @@ describe('routeInjuries', () => {
       injuryChunk(4, 0.95),
     ]);
 
-    const result = await routeInjuries([0.1, 0.2], 1);
+    const result = await routeInjuries([0.1, 0.2], 'test-model', 'v1', 1);
 
     // Beyond MAX_MATCHED_INJURIES (3) and not near-tied — the fallback
     // should still return all 4, not silently drop the 4th.

--- a/tests/integration/ai-agent-route.integration.test.ts
+++ b/tests/integration/ai-agent-route.integration.test.ts
@@ -51,6 +51,8 @@ describe('AI agent route integration', () => {
       0,
       'Physiotherapy helped improve my hip pain.',
       vectorWith(1, 0, 0),
+      'test-model',
+      'test-version',
     );
   });
 

--- a/tests/integration/data-isolation.integration.test.ts
+++ b/tests/integration/data-isolation.integration.test.ts
@@ -63,6 +63,8 @@ describe('data isolation regression tests', () => {
       0,
       'Chunk belonging to injury A',
       vectorWith(1, 0, 0),
+      'test-model',
+      'test-version',
     );
 
     await storeDocumentChunk(
@@ -73,6 +75,8 @@ describe('data isolation regression tests', () => {
       0,
       'Chunk belonging to injury B',
       vectorWith(1, 0, 0),
+      'test-model',
+      'test-version',
     );
   });
 

--- a/tests/integration/document-chunk-userid-backfill.integration.test.ts
+++ b/tests/integration/document-chunk-userid-backfill.integration.test.ts
@@ -34,10 +34,12 @@ describe('DocumentChunk userId backfill migration', () => {
     try {
       const inserted = await prisma.$queryRaw<{ id: number }[]>`
         INSERT INTO "DocumentChunk" (
-          "injuryId", "sourceType", "sourceId", "chunkIndex", "content"
+          "injuryId", "sourceType", "sourceId", "chunkIndex", "content",
+          "embeddingModel", "embeddingModelVersion"
         )
         VALUES (
-          ${injuryId}, 'backfill-migration-test', 1, 0, 'pre-existing chunk'
+          ${injuryId}, 'backfill-migration-test', 1, 0, 'pre-existing chunk',
+          'test-model', 'v1'
         )
         RETURNING "id"
       `;

--- a/tests/integration/rag-pipeline.integration.test.ts
+++ b/tests/integration/rag-pipeline.integration.test.ts
@@ -46,6 +46,8 @@ describe('RAG pipeline integration', () => {
       0,
       'Physiotherapy helped improve my hip pain.',
       vectorWith(1, 0, 0),
+      'test-model',
+      'test-version',
     );
 
     await storeDocumentChunk(
@@ -56,6 +58,8 @@ describe('RAG pipeline integration', () => {
       1,
       'I also received physiotherapy exercises.',
       vectorWith(0.9, 0.1, 0),
+      'test-model',
+      'test-version',
     );
   });
 
@@ -133,6 +137,8 @@ describe('RAG pipeline integration', () => {
         0,
         'Injury: RAG Pipeline Test. Body area: hip.',
         vectorWith(1, 0, 0),
+        'test-model',
+        'test-version',
       );
 
       // The unrelated injury's chunks sit far away in embedding space so
@@ -145,6 +151,8 @@ describe('RAG pipeline integration', () => {
         0,
         'Physical therapy for the shoulder.',
         vectorWith(0, 1, 0),
+        'test-model',
+        'test-version',
       );
 
       const result = await answerQuestion(

--- a/tests/integration/vector-storage.integration.test.ts
+++ b/tests/integration/vector-storage.integration.test.ts
@@ -61,6 +61,8 @@ describe('vector storage integration', () => {
       0,
       'Very similar chunk',
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
     );
 
     await storeDocumentChunk(
@@ -71,6 +73,8 @@ describe('vector storage integration', () => {
       1,
       'Somewhat similar chunk',
       vectorWith(0.7, 0.7, 0),
+      'test-model',
+      'v1',
     );
 
     await storeDocumentChunk(
@@ -81,10 +85,14 @@ describe('vector storage integration', () => {
       2,
       'Unrelated chunk',
       vectorWith(0, 0, 1),
+      'test-model',
+      'v1',
     );
 
     const results = await searchSimilarChunks(
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
       undefined,
       3,
       'vector-storage-integration-test',
@@ -112,6 +120,8 @@ describe('vector storage integration', () => {
       0,
       'chunk 1',
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
     );
 
     await storeDocumentChunk(
@@ -122,6 +132,8 @@ describe('vector storage integration', () => {
       1,
       'chunk 2',
       vectorWith(0.9, 0.1, 0),
+      'test-model',
+      'v1',
     );
 
     await storeDocumentChunk(
@@ -132,10 +144,14 @@ describe('vector storage integration', () => {
       2,
       'chunk 3',
       vectorWith(0, 1, 0),
+      'test-model',
+      'v1',
     );
 
     const results = await searchSimilarChunks(
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
       undefined,
       2,
       'vector-storage-integration-test',
@@ -153,6 +169,8 @@ describe('vector storage integration', () => {
       0,
       'Injury 1 relevant chunk',
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
     );
 
     await storeDocumentChunk(
@@ -163,10 +181,14 @@ describe('vector storage integration', () => {
       0,
       'Injury 2 relevant chunk',
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
     );
 
     const results = await searchSimilarChunks(
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
       injuryA.injuryId,
       5,
       'vector-storage-integration-test',
@@ -186,6 +208,8 @@ describe('vector storage integration', () => {
       0,
       'User 1 relevant chunk',
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
     );
 
     await storeDocumentChunk(
@@ -196,10 +220,14 @@ describe('vector storage integration', () => {
       0,
       'User 2 relevant chunk',
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
     );
 
     const results = await searchSimilarChunks(
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
       undefined,
       5,
       'vector-storage-integration-test',
@@ -220,6 +248,8 @@ describe('vector storage integration', () => {
       0,
       'Own sourceType chunk',
       vectorWith(0, 1, 0),
+      'test-model',
+      'v1',
     );
 
     await storeDocumentChunk(
@@ -230,10 +260,14 @@ describe('vector storage integration', () => {
       0,
       'Foreign sourceType chunk, closer vector',
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
     );
 
     const results = await searchSimilarChunks(
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
       undefined,
       5,
       'vector-storage-integration-test',
@@ -260,6 +294,8 @@ describe('vector storage integration', () => {
       0,
       'Close chunk',
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
     );
 
     await storeDocumentChunk(
@@ -270,10 +306,14 @@ describe('vector storage integration', () => {
       1,
       'Orthogonal chunk',
       vectorWith(0, 1, 0),
+      'test-model',
+      'v1',
     );
 
     const results = await searchSimilarChunks(
       vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
       undefined,
       5,
       'vector-storage-integration-test',
@@ -284,5 +324,46 @@ describe('vector storage integration', () => {
 
     expect(results).toHaveLength(1);
     expect(results[0].content).toBe('Close chunk');
+  });
+
+  it('excludes chunks embedded by a different model/version even when their vector is closest (#133)', async () => {
+    await storeDocumentChunk(
+      injuryA.injuryId,
+      injuryA.userId,
+      'vector-storage-integration-test',
+      9,
+      0,
+      'Current-model chunk, farther vector',
+      vectorWith(0.7, 0.7, 0),
+      'test-model',
+      'v1',
+    );
+
+    await storeDocumentChunk(
+      injuryA.injuryId,
+      injuryA.userId,
+      'vector-storage-integration-test',
+      9,
+      1,
+      'Old-model chunk, closest vector',
+      vectorWith(1, 0, 0),
+      'old-model',
+      'v0',
+    );
+
+    const results = await searchSimilarChunks(
+      vectorWith(1, 0, 0),
+      'test-model',
+      'v1',
+      undefined,
+      5,
+      'vector-storage-integration-test',
+      undefined,
+      undefined,
+      MAX_COSINE_DISTANCE,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('Current-model chunk, farther vector');
   });
 });

--- a/tests/semantic-search.test.ts
+++ b/tests/semantic-search.test.ts
@@ -127,7 +127,12 @@ describe('semanticSearch', () => {
 
     routeInjuriesMock.mockResolvedValue([1, 2]);
 
-    searchSimilarChunksMock.mockImplementation(async (_embedding, matchedInjuryId: number) => {
+    searchSimilarChunksMock.mockImplementation(async (
+      _embedding,
+      _embeddingModel,
+      _embeddingModelVersion,
+      matchedInjuryId: number,
+    ) => {
       if (matchedInjuryId === 1) {
         return [
           { id: 10, injuryId: 1, sourceType: 'journal', sourceId: 7, chunkIndex: 2, distance: 0.1 },

--- a/tests/semantic-search.test.ts
+++ b/tests/semantic-search.test.ts
@@ -58,10 +58,18 @@ describe('semanticSearch', () => {
       undefined,
     );
 
-    expect(routeInjuriesMock).toHaveBeenCalledWith(embedding, 1, undefined);
+    expect(routeInjuriesMock).toHaveBeenCalledWith(
+      embedding,
+      'test-model',
+      'v1',
+      1,
+      undefined,
+    );
 
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       embedding,
+      'test-model',
+      'v1',
       9,
       5,
       undefined,
@@ -84,7 +92,12 @@ describe('semanticSearch', () => {
 
     routeInjuriesMock.mockResolvedValue([1, 2]);
 
-    searchSimilarChunksMock.mockImplementation(async (_embedding, matchedInjuryId: number) => {
+    searchSimilarChunksMock.mockImplementation(async (
+      _embedding,
+      _embeddingModel,
+      _embeddingModelVersion,
+      matchedInjuryId: number,
+    ) => {
       if (matchedInjuryId === 1) {
         return [
           { id: 10, injuryId: 1, distance: 0.5 },
@@ -122,6 +135,8 @@ describe('semanticSearch', () => {
     expect(searchSimilarChunksMock).toHaveBeenCalledTimes(3);
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
+      'test-model',
+      'v1',
       1,
       2,
       undefined,
@@ -131,6 +146,8 @@ describe('semanticSearch', () => {
     );
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
+      'test-model',
+      'v1',
       2,
       2,
       undefined,
@@ -140,6 +157,8 @@ describe('semanticSearch', () => {
     );
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
+      'test-model',
+      'v1',
       3,
       2,
       undefined,
@@ -181,6 +200,8 @@ describe('semanticSearch', () => {
 
     expect(searchSimilarChunksMock).toHaveBeenCalledWith(
       [0.1, 0.2],
+      'test-model',
+      'v1',
       42,
       5,
       undefined,

--- a/tests/vector-storage.test.ts
+++ b/tests/vector-storage.test.ts
@@ -66,7 +66,17 @@ beforeEach(() => {
 
 describe('storeDocumentChunk', () => {
   it('inserts a document chunk with the embedding formatted as a pgvector literal', async () => {
-    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'some content', [0.1, 0.2, 0.3]);
+    await storeDocumentChunk(
+      1,
+      9,
+      'treatment',
+      2,
+      0,
+      'some content',
+      [0.1, 0.2, 0.3],
+      'test-model',
+      'v1',
+    );
 
     expect(executeRawMock).toHaveBeenCalledTimes(1);
 
@@ -79,35 +89,47 @@ describe('storeDocumentChunk', () => {
       0,
       'some content',
       '[0.1,0.2,0.3]',
+      'test-model',
+      'v1',
       null,
     ]);
   });
 
   it('serializes metadata to JSON when provided', async () => {
-    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'content', [0.1], {
+    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'content', [0.1], 'test-model', 'v1', {
       foo: 'bar',
     });
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[7]).toBe(JSON.stringify({ foo: 'bar' }));
+    expect(query.values[9]).toBe(JSON.stringify({ foo: 'bar' }));
   });
 
   it('uses null metadata when none is provided', async () => {
-    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'content', [0.1]);
+    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'content', [0.1], 'test-model', 'v1');
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
-    expect(query.values[7]).toBeNull();
+    expect(query.values[9]).toBeNull();
   });
 
   it('formats an empty embedding array as an empty vector literal', async () => {
-    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'content', []);
+    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'content', [], 'test-model', 'v1');
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values[6]).toBe('[]');
   });
 
   it('passes the chunkIndex and content through unchanged', async () => {
-    await storeDocumentChunk(7, 9, 'medical_visit', 3, 4, 'chunk body text', [1]);
+    await storeDocumentChunk(
+      7,
+      9,
+      'medical_visit',
+      3,
+      4,
+      'chunk body text',
+      [1],
+      'test-model',
+      'v1',
+    );
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values[0]).toBe(7);
@@ -119,14 +141,42 @@ describe('storeDocumentChunk', () => {
   });
 
   it('passes the userId through unchanged', async () => {
-    await storeDocumentChunk(1, 42, 'treatment', 2, 0, 'content', [0.1]);
+    await storeDocumentChunk(1, 42, 'treatment', 2, 0, 'content', [0.1], 'test-model', 'v1');
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
     expect(query.values[1]).toBe(42);
   });
 
+  it('passes the embeddingModel and embeddingModelVersion through unchanged', async () => {
+    await storeDocumentChunk(
+      1,
+      9,
+      'treatment',
+      2,
+      0,
+      'content',
+      [0.1],
+      'Qwen/Qwen3-Embedding-0.6B',
+      'abc123',
+    );
+
+    const query = executeRawMock.mock.calls[0][0] as SqlResult;
+    expect(query.values[7]).toBe('Qwen/Qwen3-Embedding-0.6B');
+    expect(query.values[8]).toBe('abc123');
+  });
+
   it('uses the correct ON CONFLICT clause for upserting by (sourceType, sourceId, chunkIndex)', async () => {
-    await storeDocumentChunk(1, 9, 'treatment', 2, 0, 'some content', [0.1, 0.2, 0.3]);
+    await storeDocumentChunk(
+      1,
+      9,
+      'treatment',
+      2,
+      0,
+      'some content',
+      [0.1, 0.2, 0.3],
+      'test-model',
+      'v1',
+    );
 
     const query = executeRawMock.mock.calls[0][0] as SqlResult;
     const sql = query.strings.join('');
@@ -136,6 +186,8 @@ describe('storeDocumentChunk', () => {
     expect(sql).toContain('"userId" = EXCLUDED."userId"');
     expect(sql).toContain('"content" = EXCLUDED."content"');
     expect(sql).toContain('"embedding" = EXCLUDED."embedding"');
+    expect(sql).toContain('"embeddingModel" = EXCLUDED."embeddingModel"');
+    expect(sql).toContain('"embeddingModelVersion" = EXCLUDED."embeddingModelVersion"');
     expect(sql).toContain('"metadata" = EXCLUDED."metadata"');
   });
 });
@@ -171,7 +223,7 @@ describe('deleteDocumentChunksExcept', () => {
 
 describe('searchSimilarChunks', () => {
   it('formats the embedding as a pgvector literal and passes limit through', async () => {
-    await searchSimilarChunks([0.1, 0.2, 0.3], undefined, 7);
+    await searchSimilarChunks([0.1, 0.2, 0.3], 'test-model', 'v1', undefined, 7);
 
     expect(queryRawMock).toHaveBeenCalledTimes(1);
     expect(joinMock).toHaveBeenCalledTimes(1);
@@ -183,12 +235,12 @@ describe('searchSimilarChunks', () => {
   });
 
   it('always applies a distance-threshold filter, defaulting to DEFAULT_DISTANCE_THRESHOLD', async () => {
-    await searchSimilarChunks([1]);
+    await searchSimilarChunks([1], 'test-model', 'v1');
 
     expect(joinMock).toHaveBeenCalledTimes(1);
     const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
     expect(separator).toBe(' AND ');
-    expect(filters).toHaveLength(1);
+    expect(filters).toHaveLength(3);
     expect(filters[0].values).toEqual(['[1]', DEFAULT_DISTANCE_THRESHOLD]);
     expect(filters[0].strings.join('')).toContain('"embedding" <=>');
 
@@ -196,70 +248,90 @@ describe('searchSimilarChunks', () => {
     expect(query.values[3]).toBe(5);
   });
 
+  it('always filters by embeddingModel and embeddingModelVersion, so vectors from a different model are never compared', async () => {
+    await searchSimilarChunks([1], 'Qwen/Qwen3-Embedding-0.6B', 'abc123');
+
+    const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(filters[1].values).toEqual(['Qwen/Qwen3-Embedding-0.6B']);
+    expect(filters[1].strings.join('')).toContain('"embeddingModel"');
+    expect(filters[2].values).toEqual(['abc123']);
+    expect(filters[2].strings.join('')).toContain('"embeddingModelVersion"');
+  });
+
   it('uses the provided maxDistance instead of the default', async () => {
-    await searchSimilarChunks([1], undefined, 5, undefined, undefined, undefined, 0.3);
+    await searchSimilarChunks(
+      [1],
+      'test-model',
+      'v1',
+      undefined,
+      5,
+      undefined,
+      undefined,
+      undefined,
+      0.3,
+    );
 
     const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
     expect(filters[0].values).toEqual(['[1]', 0.3]);
   });
 
   it('filters by injuryId in addition to the distance threshold when sourceType is omitted', async () => {
-    await searchSimilarChunks([1], 42);
-
-    expect(joinMock).toHaveBeenCalledTimes(1);
-    const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
-    expect(separator).toBe(' AND ');
-    expect(filters).toHaveLength(2);
-    expect(filters[1].values).toEqual([42]);
-    expect(filters[1].strings.join('')).toContain('"injuryId"');
-  });
-
-  it('filters by sourceType in addition to the distance threshold when injuryId is omitted', async () => {
-    await searchSimilarChunks([1], undefined, 5, 'treatment');
-
-    expect(joinMock).toHaveBeenCalledTimes(1);
-    const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
-    expect(filters).toHaveLength(2);
-    expect(filters[1].values).toEqual(['treatment']);
-    expect(filters[1].strings.join('')).toContain('"sourceType"');
-  });
-
-  it('filters by both injuryId and sourceType when both are provided', async () => {
-    await searchSimilarChunks([1], 42, 5, 'treatment');
-
-    expect(joinMock).toHaveBeenCalledTimes(1);
-    const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
-    expect(separator).toBe(' AND ');
-    expect(filters).toHaveLength(3);
-    expect(filters[1].values).toEqual([42]);
-    expect(filters[1].strings.join('')).toContain('"injuryId"');
-    expect(filters[2].values).toEqual(['treatment']);
-    expect(filters[2].strings.join('')).toContain('"sourceType"');
-  });
-
-  it('filters by userId in addition to the distance threshold when injuryId and sourceType are omitted', async () => {
-    await searchSimilarChunks([1], undefined, 5, undefined, 42);
-
-    expect(joinMock).toHaveBeenCalledTimes(1);
-    const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
-    expect(filters).toHaveLength(2);
-    expect(filters[1].values).toEqual([42]);
-    expect(filters[1].strings.join('')).toContain('"userId"');
-  });
-
-  it('filters by injuryId, sourceType, and userId together when all are provided', async () => {
-    await searchSimilarChunks([1], 42, 5, 'treatment', 7);
+    await searchSimilarChunks([1], 'test-model', 'v1', 42);
 
     expect(joinMock).toHaveBeenCalledTimes(1);
     const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
     expect(separator).toBe(' AND ');
     expect(filters).toHaveLength(4);
-    expect(filters[1].values).toEqual([42]);
-    expect(filters[1].strings.join('')).toContain('"injuryId"');
-    expect(filters[2].values).toEqual(['treatment']);
-    expect(filters[2].strings.join('')).toContain('"sourceType"');
-    expect(filters[3].values).toEqual([7]);
+    expect(filters[3].values).toEqual([42]);
+    expect(filters[3].strings.join('')).toContain('"injuryId"');
+  });
+
+  it('filters by sourceType in addition to the distance threshold when injuryId is omitted', async () => {
+    await searchSimilarChunks([1], 'test-model', 'v1', undefined, 5, 'treatment');
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(filters).toHaveLength(4);
+    expect(filters[3].values).toEqual(['treatment']);
+    expect(filters[3].strings.join('')).toContain('"sourceType"');
+  });
+
+  it('filters by both injuryId and sourceType when both are provided', async () => {
+    await searchSimilarChunks([1], 'test-model', 'v1', 42, 5, 'treatment');
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(separator).toBe(' AND ');
+    expect(filters).toHaveLength(5);
+    expect(filters[3].values).toEqual([42]);
+    expect(filters[3].strings.join('')).toContain('"injuryId"');
+    expect(filters[4].values).toEqual(['treatment']);
+    expect(filters[4].strings.join('')).toContain('"sourceType"');
+  });
+
+  it('filters by userId in addition to the distance threshold when injuryId and sourceType are omitted', async () => {
+    await searchSimilarChunks([1], 'test-model', 'v1', undefined, 5, undefined, 42);
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(filters).toHaveLength(4);
+    expect(filters[3].values).toEqual([42]);
     expect(filters[3].strings.join('')).toContain('"userId"');
+  });
+
+  it('filters by injuryId, sourceType, and userId together when all are provided', async () => {
+    await searchSimilarChunks([1], 'test-model', 'v1', 42, 5, 'treatment', 7);
+
+    expect(joinMock).toHaveBeenCalledTimes(1);
+    const [filters, separator] = joinMock.mock.calls[0] as [SqlResult[], string];
+    expect(separator).toBe(' AND ');
+    expect(filters).toHaveLength(6);
+    expect(filters[3].values).toEqual([42]);
+    expect(filters[3].strings.join('')).toContain('"injuryId"');
+    expect(filters[4].values).toEqual(['treatment']);
+    expect(filters[4].strings.join('')).toContain('"sourceType"');
+    expect(filters[5].values).toEqual([7]);
+    expect(filters[5].strings.join('')).toContain('"userId"');
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `embeddingModel`/`embeddingModelVersion` as real, indexed columns on `DocumentChunk`,
  backfilled from the existing (unindexed) `metadata.embedding` JSON
- `searchSimilarChunks` now always filters on both, so cosine search never compares vectors
  produced by different embedding models/versions
- Threads the query embedding's model/version through `semanticSearch` and `routeInjuries`
  so the guard applies to every retrieval path

## Why
`DocumentChunk.embedding` is `vector(1024)` with no record of which model produced it. If the
embedding model is ever changed, old and new vectors would silently mix in cosine search with
no error — this closes that gap and lets a future model migration be done as a gradual
background re-embed instead of a hard cutover.

Fixes #133

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint`, `npm test` (350/350 passing)
- [x] New integration test proves a chunk embedded by a different model/version is excluded
      from search results even when its vector is closest by distance
- [x] Security review (sub-agent scan): no findings
- [x] Self-review: no blocking findings