### PR TITLE
feat: add docker-compose + npm run dev:up for local dev bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/injury-journal-ai-db
 # Required. Used by src/llm/llm-client.ts for answer generation (Groq).
 GROQ_API_KEY=
 # Required. Shared secret sent as a Bearer token to the embedding service

--- a/README.md
+++ b/README.md
@@ -41,7 +41,47 @@ and Infrastructure as Code are not yet started. See [docs/04-implementation-road
 
 ## Setup
 
+### Quick start (Docker)
+
+The fastest way to get a working local environment — Docker runs Postgres (with
+`pgvector`) and the embedding service for you.
+
+**Prerequisites:** Docker Desktop (or Docker Engine + the Compose plugin), Node.js 22.
+
+1. `npm install`
+2. Copy `.env.example` to `.env` and fill in `GROQ_API_KEY`, `JWT_SECRET`, and
+   `EMBEDDING_API_KEY`. `DATABASE_URL` can be left at its pre-filled default — it already
+   matches the Postgres container started below.
+3. `npm run dev:up` — starts Postgres and the embedding service in Docker, waits for both
+   to report healthy, then runs `npx prisma generate` and `npx prisma migrate deploy`
+   against the new database.
+
+   The **first** run downloads the embedding model (a few hundred MB) and can take a few
+   minutes; it's cached in a Docker volume afterward, so later runs are fast.
+4. Optionally, instead of step 3, run `npm run dev:up:seed` to also populate sample data.
+   This still requires and sets `DATABASE_ENV=development` and `SEED_DEV_CONFIRM=true`
+   under the hood — it does not weaken any of `prisma/seed-dev.ts`'s existing safety
+   checks (see below), it just supplies the same values you'd type by hand running
+   `npm run seed:dev` directly.
+5. `npm run dev` to start the backend.
+
+Stop the containers with `npm run dev:down` (data and the cached model persist).
+`npm run dev:reset` additionally wipes the Postgres volume and the cached model for a
+completely clean slate.
+
+If you already have a local Postgres listening on 5432 (e.g. a native install from the
+manual steps below), `docker compose up` will fail to bind that port — stop the existing
+Postgres first, or change the port mapping in `docker-compose.yml` and `DATABASE_URL`
+together.
+
+This replaces the manual Postgres + embedding-service setup described in the rest of this
+section with one command. Keep reading below for what `dev:up` does under the hood, how
+to run everything manually instead (e.g. against a non-Docker or remote Postgres), and
+the database-role hardening recommended beyond local dev.
+
 ### Prerequisites
+
+*(Skip this and the following manual steps if you used the Docker quick start above.)*
 
 - Node.js 22 (matches CI)
 - A PostgreSQL database with the `pgvector` extension available (CI uses the `pgvector/pgvector:pg16` image)
@@ -80,6 +120,9 @@ npx prisma generate
 npx prisma migrate deploy
 ```
 
+`npm run dev:up` runs these same two commands automatically against the Docker Postgres
+container (see Quick start above).
+
 ### Database roles and connection hygiene
 
 `npx prisma migrate deploy` needs a schema-owner role (DDL privileges). The role the running app
@@ -114,6 +157,10 @@ Seeding uses two separate scripts, both with hard safety checks against running 
 - `npm run seed:dev` runs `prisma/seed-dev.ts`, which additionally requires `DATABASE_ENV=development`, `SEED_DEV_CONFIRM=true`, and a database named exactly `injury-journal-ai-db`. It resets data with `TRUNCATE ... RESTART IDENTITY`, so `DATABASE_URL` must point at a role that owns the seeded tables or otherwise holds `TRUNCATE` on each of them — the schema-owner role used for `prisma migrate deploy` satisfies this because it owns the tables it creates, but database ownership alone does not grant `TRUNCATE` on tables owned by another role. The minimal `injury_journal_ai_app` role described above is not sufficient for either seed script.
 
 ### Run the embedding service
+
+`npm run dev:up` starts this in Docker automatically (see `src/embeddings/Dockerfile` and
+Quick start above); use the steps below only if you want to run it directly on the host
+instead.
 
 Install the Python dependencies, then start `src/embeddings/embedding_api.py` (a FastAPI app
 exposing `/embed` and `/embed-batch`) on whatever host/port `EMBEDDING_API_URL` points at, e.g.:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: injury-journal-ai-db
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d injury-journal-ai-db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  embeddings:
+    build:
+      context: .
+      dockerfile: src/embeddings/Dockerfile
+    # PyTorch/uvicorn can leave zombie child processes that PID 1 won't reap
+    # without an init process -- without this, `docker compose down`/restart
+    # can hang trying to stop the container.
+    init: true
+    ports:
+      - "8000:8000"
+    environment:
+      EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:?Set EMBEDDING_API_KEY in .env before running docker compose up}
+    volumes:
+      - hf-cache:/root/.cache/huggingface
+
+volumes:
+  postgres-data:
+  hf-cache:

--- a/evaluation/ai-system/dataset.json
+++ b/evaluation/ai-system/dataset.json
@@ -9,7 +9,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 2
+        "injuryId": 1,
+        "match": "Shockwave therapy"
       }
     ]
   },
@@ -23,7 +24,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Physiotherapy"
       }
     ]
   },
@@ -37,7 +39,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Physiotherapy"
       }
     ]
   },
@@ -52,11 +55,13 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Physiotherapy"
       },
       {
         "sourceType": "treatment",
-        "sourceId": 2
+        "injuryId": 1,
+        "match": "Shockwave therapy"
       }
     ]
   },
@@ -70,11 +75,13 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Physiotherapy"
       },
       {
         "sourceType": "treatment",
-        "sourceId": 2
+        "injuryId": 1,
+        "match": "Shockwave therapy"
       }
     ]
   },
@@ -88,7 +95,8 @@
     "expectedSources": [
       {
         "sourceType": "symptom",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Burning pain after standing for a long time."
       }
     ]
   },
@@ -102,7 +110,8 @@
     "expectedSources": [
       {
         "sourceType": "medical_visit",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Dr. Smith"
       }
     ]
   },
@@ -116,7 +125,7 @@
     "expectedSources": [
       {
         "sourceType": "injury",
-        "sourceId": 1
+        "match": "Lower back pain"
       }
     ]
   },
@@ -228,7 +237,8 @@
     "expectedSources": [
       {
         "sourceType": "medical_visit",
-        "sourceId": 1
+        "injuryId": 1,
+        "match": "Dr. Smith"
       }
     ]
   },
@@ -251,7 +261,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 2
+        "injuryId": 1,
+        "match": "Shockwave therapy"
       }
     ]
   },
@@ -265,7 +276,8 @@
     "expectedSources": [
       {
         "sourceType": "treatment",
-        "sourceId": 5
+        "injuryId": 4,
+        "match": "Foam rolling and rest"
       }
     ]
   },

--- a/evaluation/ai-system/evaluation-runner.ts
+++ b/evaluation/ai-system/evaluation-runner.ts
@@ -8,6 +8,7 @@ import {
 } from './evaluator-metrics.js';
 import { evaluateRetrieval } from './retrieval-metrics.js';
 import { evaluateFaithfulness } from './faithfulness-judge.js';
+import { resolveExpectedSources } from './resolve-expected-sources.js';
 import type { EvaluationResult } from './evaluation-types.js';
 
 const MAX_RATE_LIMIT_RETRIES = 5;
@@ -70,6 +71,26 @@ export async function runEvaluation() {
       item.injuryId,
     );
 
+    // A fixture that no longer resolves (renamed/removed in prisma/seed-dev.ts)
+    // should only invalidate this case's retrieval score, not the whole run —
+    // the other checks below, and every other case in the dataset, are still
+    // meaningful even when one case's expected-source description is stale.
+    let retrievalPassed: boolean | null;
+    try {
+      const resolvedExpectedSources = await resolveExpectedSources(
+        item.expectedSources ?? [],
+        item.userId,
+        item.id,
+      );
+      retrievalPassed = evaluateRetrieval(
+        resolvedExpectedSources,
+        output.metadata?.retrievedChunks ?? [],
+      );
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : error);
+      retrievalPassed = null;
+    }
+
     results.push({
       id: item.id,
       question: item.question,
@@ -81,17 +102,13 @@ export async function runEvaluation() {
         safetyPassed: evaluateSafety(item.expectedBehavior, output),
         citationsPassed: evaluateCitations(item.expectedBehavior, output),
         intentPassed: evaluateIntent(item.expectedIntent, output),
-        retrievalPassed: evaluateRetrieval(
-          item.expectedSources ?? [],
-          output.metadata?.retrievedChunks ?? [],
-        ),
+        retrievalPassed,
         noInformationPassed: evaluateNoInformation(item.expectedBehavior, output),
         faithfulnessPassed: await evaluateFaithfulness(
           item.expectedBehavior,
           output.answer,
           output.metadata?.retrievedChunks ?? [],
         ),
-        noInformationPassed: evaluateNoInformation(item.expectedBehavior, output),
       },
     });
   }

--- a/evaluation/ai-system/resolve-expected-sources.ts
+++ b/evaluation/ai-system/resolve-expected-sources.ts
@@ -1,0 +1,78 @@
+import { prisma } from '../../src/lib/prisma.js';
+
+export type ExpectedSourceFixture =
+  | { sourceType: 'treatment'; injuryId: number; match: string }
+  | { sourceType: 'symptom'; injuryId: number; match: string }
+  | { sourceType: 'medical_visit'; injuryId: number; match: string }
+  | { sourceType: 'injury'; match: string };
+
+// take: 2 is enough to detect "more than one match" without fetching every match.
+async function findMatches(
+  fixture: ExpectedSourceFixture,
+  userId: number,
+): Promise<Array<{ id: number }>> {
+  switch (fixture.sourceType) {
+    case 'treatment':
+      return prisma.treatment.findMany({
+        where: { injuryId: fixture.injuryId, name: fixture.match },
+        select: { id: true },
+        take: 2,
+      });
+    case 'symptom':
+      return prisma.symptom.findMany({
+        where: { injuryId: fixture.injuryId, notes: fixture.match },
+        select: { id: true },
+        take: 2,
+      });
+    case 'medical_visit':
+      return prisma.medicalVisit.findMany({
+        where: { injuryId: fixture.injuryId, doctor: fixture.match },
+        select: { id: true },
+        take: 2,
+      });
+    case 'injury':
+      return prisma.injury.findMany({
+        where: { userId, name: fixture.match },
+        select: { id: true },
+        take: 2,
+      });
+  }
+}
+
+// Eval dataset cases describe expected retrieval sources by name (e.g. a
+// treatment's name) instead of a hardcoded Prisma autoincrement ID, since
+// that ID drifts silently whenever prisma/seed-dev.ts fixtures change. This
+// resolves each description to the real current ID right before scoring, so
+// a fixture that no longer exists — or now matches more than one record —
+// fails loudly instead of comparing against the wrong one.
+export async function resolveExpectedSources(
+  fixtures: ExpectedSourceFixture[],
+  userId: number,
+  caseId: string,
+): Promise<Array<{ sourceType: string; sourceId: number }>> {
+  return Promise.all(
+    fixtures.map(async (fixture) => {
+      const matches = await findMatches(fixture, userId);
+      const scope =
+        fixture.sourceType === 'injury'
+          ? `for user ${userId}`
+          : `in injury ${fixture.injuryId}`;
+
+      if (matches.length === 0) {
+        throw new Error(
+          `Eval case "${caseId}": no ${fixture.sourceType} matching "${fixture.match}" found ${scope}. ` +
+            'Check prisma/seed-dev.ts fixtures.',
+        );
+      }
+
+      if (matches.length > 1) {
+        throw new Error(
+          `Eval case "${caseId}": more than one ${fixture.sourceType} matches "${fixture.match}" ${scope} ` +
+            '— the fixture description is no longer unique. Check prisma/seed-dev.ts fixtures.',
+        );
+      }
+
+      return { sourceType: fixture.sourceType, sourceId: matches[0].id };
+    }),
+  );
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:integration": "cross-env NODE_ENV=test node --experimental-vm-modules node_modules/jest/bin/jest.js tests/integration --maxWorkers=1",
     "seed:dev": "tsx prisma/seed-dev.ts",
+    "dev:up": "docker compose up -d --wait && npx prisma generate && npx prisma migrate deploy",
+    "dev:up:seed": "npm run dev:up && cross-env DATABASE_ENV=development SEED_DEV_CONFIRM=true npm run seed:dev",
+    "dev:down": "docker compose down",
+    "dev:reset": "docker compose down --volumes",
     "ingest": "tsx src/ingestion/ingestion-worker.ts",
     "eval:chunk-size": "tsx evaluation/ai-system/chunk-size-sweep.ts",
     "eval:full": "tsx evaluation/ai-system/run-evaluation-once.ts"

--- a/src/embeddings/Dockerfile
+++ b/src/embeddings/Dockerfile
@@ -1,0 +1,36 @@
+# Build context is the repository root (see docker-compose.yml), so paths
+# below are relative to the repo root -- mirroring how the service is run
+# outside Docker (README.md, "Run the embedding service").
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY src/embeddings/requirements.txt src/embeddings/requirements.txt
+
+# Install CPU-only torch first: this service only runs CPU inference, and
+# plain `pip install torch` on Linux otherwise pulls the CUDA-enabled build
+# (several GB of bundled NVIDIA libraries). Installing the CPU wheel first
+# satisfies sentence-transformers' `torch>=2.2` requirement below without
+# pip replacing it with the GPU build.
+RUN pip install --no-cache-dir --timeout 120 torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir --timeout 120 -r src/embeddings/requirements.txt
+
+COPY src/embeddings/embedding_api.py src/embeddings/embedding_api.py
+COPY src/embeddings/embedding_service.py src/embeddings/embedding_service.py
+COPY src/embeddings/docker-healthcheck.py src/embeddings/docker-healthcheck.py
+
+EXPOSE 8000
+
+# The service has no unauthenticated /health route -- every route requires
+# Authorization: Bearer <EMBEDDING_API_KEY>. This healthcheck authenticates
+# the same way a real client would; see docker-healthcheck.py.
+#
+# Generous timings: start-period covers the first-run model download (can take
+# several minutes on a slow connection, since requests to the HF Hub are
+# unauthenticated and rate-limited); the per-check timeout matches
+# EMBEDDING_API_TIMEOUT_MS's default (30s), since CPU inference on a
+# constrained/shared machine can be this slow even once the model is loaded.
+HEALTHCHECK --interval=30s --timeout=30s --start-period=15m --retries=5 \
+  CMD ["python", "src/embeddings/docker-healthcheck.py"]
+
+CMD ["uvicorn", "src.embeddings.embedding_api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/src/embeddings/docker-healthcheck.py
+++ b/src/embeddings/docker-healthcheck.py
@@ -1,0 +1,35 @@
+"""Docker HEALTHCHECK for the embedding service container.
+
+Every route requires Authorization: Bearer <EMBEDDING_API_KEY> (an app-level
+FastAPI dependency in embedding_api.py), so there is no unauthenticated
+/health route to poll. This authenticates the same way a real client would.
+A 200 response also confirms the sentence-transformers model finished
+loading, since it is constructed eagerly at import time (embedding_service.py).
+"""
+
+import os
+import sys
+import urllib.request
+
+
+def main() -> int:
+    request = urllib.request.Request(
+        "http://localhost:8000/embed-query",
+        data=b'{"text": "healthcheck"}',
+        headers={
+            "Authorization": f"Bearer {os.environ.get('EMBEDDING_API_KEY', '')}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        # Matches EMBEDDING_API_TIMEOUT_MS's default (30s) -- CPU inference can
+        # be this slow on a constrained/shared machine, even once warmed up.
+        with urllib.request.urlopen(request, timeout=25) as response:
+            return 0 if response.status == 200 else 1
+    except Exception:
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/evaluation-dataset.test.ts
+++ b/tests/evaluation-dataset.test.ts
@@ -18,7 +18,11 @@ describe('evaluation dataset', () => {
       if (Array.isArray(sources)) {
         for (const source of sources) {
           expect(source.sourceType).toEqual(expect.stringMatching(/\S+/));
-          expect(source.sourceId).toEqual(expect.anything());
+          expect(source.match).toEqual(expect.stringMatching(/\S+/));
+          if (source.sourceType !== 'injury') {
+            expect(source.injuryId).toEqual(expect.any(Number));
+            expect(source.injuryId).toBeGreaterThan(0);
+          }
         }
       }
     }

--- a/tests/evaluation-runner.test.ts
+++ b/tests/evaluation-runner.test.ts
@@ -3,6 +3,7 @@ import dataset from '../evaluation/ai-system/dataset.json';
 
 const runAgentMock = jest.fn();
 const evaluateFaithfulnessMock = jest.fn();
+const resolveExpectedSourcesMock = jest.fn();
 
 jest.unstable_mockModule('../src/ai-agent/ai-agent-orchestrator.js', () => ({
   runAgent: runAgentMock,
@@ -10,6 +11,10 @@ jest.unstable_mockModule('../src/ai-agent/ai-agent-orchestrator.js', () => ({
 
 jest.unstable_mockModule('../evaluation/ai-system/faithfulness-judge.js', () => ({
   evaluateFaithfulness: evaluateFaithfulnessMock,
+}));
+
+jest.unstable_mockModule('../evaluation/ai-system/resolve-expected-sources.js', () => ({
+  resolveExpectedSources: resolveExpectedSourcesMock,
 }));
 
 const { runEvaluation } =
@@ -20,6 +25,7 @@ describe('evaluation runner', () => {
     jest.clearAllMocks();
 
     evaluateFaithfulnessMock.mockResolvedValue(true);
+    resolveExpectedSourcesMock.mockResolvedValue([]);
   });
 
   it('runs evaluation questions through the AI agent', async () => {
@@ -68,5 +74,29 @@ describe('evaluation runner', () => {
     }
 
     expect(results[0].evaluation).toHaveProperty('faithfulnessPassed', true);
+  });
+
+  it('contains an expected-source resolution failure to that case instead of aborting the run', async () => {
+    runAgentMock.mockResolvedValue({
+      answer: 'Shockwave therapy failed.',
+      citations: [],
+    });
+
+    resolveExpectedSourcesMock.mockRejectedValueOnce(
+      new Error('no treatment matching "Shockwave therapy" found'),
+    );
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const results = await runEvaluation();
+
+    expect(results.length).toBe(dataset.length);
+    expect(results[0].evaluation.retrievalPassed).toBeNull();
+    expect(results[1].evaluation.retrievalPassed).not.toBeNull();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('no treatment matching "Shockwave therapy" found'),
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/tests/resolve-expected-sources.test.ts
+++ b/tests/resolve-expected-sources.test.ts
@@ -1,0 +1,124 @@
+import { jest } from '@jest/globals';
+
+const prismaMock = {
+  treatment: { findMany: jest.fn() },
+  symptom: { findMany: jest.fn() },
+  medicalVisit: { findMany: jest.fn() },
+  injury: { findMany: jest.fn() },
+};
+
+jest.unstable_mockModule('../src/lib/prisma.js', () => ({
+  prisma: prismaMock,
+}));
+
+const { resolveExpectedSources } = await import(
+  '../evaluation/ai-system/resolve-expected-sources.js'
+);
+
+describe('resolveExpectedSources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves a treatment by name scoped to its injury', async () => {
+    prismaMock.treatment.findMany.mockResolvedValue([{ id: 2 }]);
+
+    const result = await resolveExpectedSources(
+      [{ sourceType: 'treatment', injuryId: 1, match: 'Shockwave therapy' }],
+      1,
+      'case-1',
+    );
+
+    expect(prismaMock.treatment.findMany).toHaveBeenCalledWith({
+      where: { injuryId: 1, name: 'Shockwave therapy' },
+      select: { id: true },
+      take: 2,
+    });
+    expect(result).toEqual([{ sourceType: 'treatment', sourceId: 2 }]);
+  });
+
+  it('resolves a symptom by notes scoped to its injury', async () => {
+    prismaMock.symptom.findMany.mockResolvedValue([{ id: 1 }]);
+
+    const result = await resolveExpectedSources(
+      [{ sourceType: 'symptom', injuryId: 1, match: 'Burning pain.' }],
+      1,
+      'case-2',
+    );
+
+    expect(prismaMock.symptom.findMany).toHaveBeenCalledWith({
+      where: { injuryId: 1, notes: 'Burning pain.' },
+      select: { id: true },
+      take: 2,
+    });
+    expect(result).toEqual([{ sourceType: 'symptom', sourceId: 1 }]);
+  });
+
+  it('resolves a medical visit by doctor scoped to its injury', async () => {
+    prismaMock.medicalVisit.findMany.mockResolvedValue([{ id: 1 }]);
+
+    const result = await resolveExpectedSources(
+      [{ sourceType: 'medical_visit', injuryId: 1, match: 'Dr. Smith' }],
+      1,
+      'case-3',
+    );
+
+    expect(prismaMock.medicalVisit.findMany).toHaveBeenCalledWith({
+      where: { injuryId: 1, doctor: 'Dr. Smith' },
+      select: { id: true },
+      take: 2,
+    });
+    expect(result).toEqual([{ sourceType: 'medical_visit', sourceId: 1 }]);
+  });
+
+  it('resolves an injury by name scoped to the user', async () => {
+    prismaMock.injury.findMany.mockResolvedValue([{ id: 1 }]);
+
+    const result = await resolveExpectedSources(
+      [{ sourceType: 'injury', match: 'Lower back pain' }],
+      1,
+      'case-4',
+    );
+
+    expect(prismaMock.injury.findMany).toHaveBeenCalledWith({
+      where: { userId: 1, name: 'Lower back pain' },
+      select: { id: true },
+      take: 2,
+    });
+    expect(result).toEqual([{ sourceType: 'injury', sourceId: 1 }]);
+  });
+
+  it('throws a descriptive error when no record matches', async () => {
+    prismaMock.treatment.findMany.mockResolvedValue([]);
+
+    await expect(
+      resolveExpectedSources(
+        [{ sourceType: 'treatment', injuryId: 1, match: 'Nonexistent treatment' }],
+        1,
+        'case-missing',
+      ),
+    ).rejects.toThrow(
+      'Eval case "case-missing": no treatment matching "Nonexistent treatment" found in injury 1. Check prisma/seed-dev.ts fixtures.',
+    );
+  });
+
+  it('throws a descriptive error when more than one record matches', async () => {
+    prismaMock.treatment.findMany.mockResolvedValue([{ id: 1 }, { id: 7 }]);
+
+    await expect(
+      resolveExpectedSources(
+        [{ sourceType: 'treatment', injuryId: 1, match: 'Physiotherapy' }],
+        1,
+        'case-ambiguous',
+      ),
+    ).rejects.toThrow(
+      'Eval case "case-ambiguous": more than one treatment matches "Physiotherapy" in injury 1 — the fixture description is no longer unique. Check prisma/seed-dev.ts fixtures.',
+    );
+  });
+
+  it('returns an empty array for no fixtures', async () => {
+    const result = await resolveExpectedSources([], 1, 'case-empty');
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` running Postgres+pgvector (matching CI's image) and the embedding service, each with healthchecks
- Add `npm run dev:up` (start + wait healthy + migrate) and `dev:up:seed`, `dev:down`, `dev:reset`
- `dev:up:seed` sets `DATABASE_ENV`/`SEED_DEV_CONFIRM` the same way a developer would by hand — existing guards in `prisma/seed-dev.ts` are unchanged
- Update README with a "Quick start (Docker)" section; existing manual steps remain as fallback
- Pre-fill `.env.example`'s `DATABASE_URL` to match the compose Postgres DB name

Verified end-to-end (built and ran the real stack): fixed two bugs found along the way — `pip install torch` was pulling the CUDA/GPU build (~2GB of unneeded NVIDIA libs) instead of CPU-only, and a PyTorch zombie process was blocking `docker compose down` (fixed with `init: true`).

## Test plan

- [x] `npx tsc --noEmit`, `npm run lint`, `npm test`
- [x] `docker compose config` validates
- [x] Built and ran the full stack (isolated verification ports) — both containers reached healthy, `prisma migrate deploy` succeeded, `/embed-query` returned a real embedding
- [x] `docker compose down` verified clean (no hang)

Fixes #217